### PR TITLE
Added ranking with retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,26 @@
 # Warren Buffett Intelligence Hub
 
-RAG chatbot and stock analysis platform built on Berkshire Hathaway shareholder letters and curated Q&A datasets. Features a React frontend with FastAPI backend, FAISS vector search, and FLAN-T5 / Groq Llama 3 for answer generation.
-
-## Prerequisites
-
-- Python 3.12+
-- Node.js 18+
-- npm 9+
+RAG chatbot and stock analysis platform that answers questions about Warren Buffett using shareholder letters and curated Q&A datasets. Ask about Buffett's philosophy, or ask what he'd think of any stock -- it fetches live financial data, runs backtests, and applies Buffett's principles.
 
 ## Setup
 
-### 1. Backend (Python)
+### 1. Backend
 
 ```bash
-# Clone and navigate to the project
-cd CSYE7380
-
-# Create virtual environment
 python3.12 -m venv venv
 source venv/bin/activate
-
-# Install Python dependencies
 pip install -r requirements.txt
-
-# Build the FAISS vector index (run once, takes ~1-2 min)
-python ingest.py
+python ingest.py        # builds FAISS + BM25 indexes (~1 min)
 ```
 
-### 2. Frontend (React)
+### 2. Frontend
 
 ```bash
 cd ui
 npm install
 ```
 
-### 3. Optional: Better answers with Groq
+### 3. Groq API Key (recommended)
 
 Create a `.env` file in the project root:
 
@@ -42,87 +28,98 @@ Create a `.env` file in the project root:
 GROQ_API_KEY=your_key_here
 ```
 
-Sign up at https://console.groq.com for a free API key. This switches from local FLAN-T5 to Llama 3.3-70B for higher quality responses.
+Free key at https://console.groq.com. Switches from local FLAN-T5 to Llama 3.3-70B for much better answers.
 
-## Running the App
+## Running
 
-You need **two terminals** — one for the backend, one for the frontend.
-
-**Terminal 1 — FastAPI Backend:**
-
+**Terminal 1 -- Backend:**
 ```bash
 source venv/bin/activate
 uvicorn server:app --reload --port 8000
 ```
 
-**Terminal 2 — React Frontend:**
-
+**Terminal 2 -- Frontend:**
 ```bash
 cd ui
 npm run dev
 ```
 
-Open **http://localhost:5173** in your browser.
+Open http://localhost:5173.
+
+**Streamlit UI** (alternative, no frontend needed):
+```bash
+streamlit run app.py
+```
+
+## How It Works
+
+```
+Question → Embed (MiniLM) → Hybrid Search (BM25 + FAISS) → Cross-Encoder Reranking → Generate (FLAN-T5 or Llama 3) → Answer + Sources
+```
+
+1. **Ingestion** (`ingest.py`): Extracts text from the PDF, chunks it (1000 chars, 200 overlap), parses and deduplicates CSV Q&A pairs, embeds everything with `paraphrase-MiniLM-L6-v2`, and stores in both a FAISS vector index and a BM25 keyword index.
+
+2. **Retrieval** (`retriever.py`): Runs FAISS semantic search and BM25 keyword search in parallel, merges results via Reciprocal Rank Fusion (RRF), then reranks the top 10 candidates down to 5 using a cross-encoder (`ms-marco-MiniLM-L-6-v2`). Supports conversation memory -- short follow-up questions are enriched with prior context.
+
+3. **Generation** (`rag_chain.py`): Feeds retrieved context into the LLM prompt and generates an answer. Uses Groq Llama 3.3-70B if API key is set, otherwise falls back to local FLAN-T5-base on CPU.
+
+4. **Stock Analysis** (`stock_analysis.py` + `trading_backtest.py`): When a user asks about a specific stock (e.g. "What would Buffett think of AAPL?"), fetches live financial data from Yahoo Finance (P/E, ROE, debt, margins), runs backtests (MA Crossover 20/50, RSI 30/70) on historical data since 2018, retrieves Buffett's principles from the RAG knowledge base, and generates a combined analysis.
+
+5. **API** (`server.py`): FastAPI backend exposing `POST /api/chat`, stock analysis endpoints, and evaluation endpoints. Called by the React frontend.
+
+6. **UI** (`ui/`): React + Tailwind dark-themed frontend with four pages -- portfolio overview, RAG chatbot, stock trading/backtesting, and RAG evaluation dashboard.
+
+7. **Evaluation** (`evaluate.py`): Benchmarks the retrieval pipeline with 15 test questions across difficulty levels. Compares FAISS-only vs Hybrid vs Hybrid+Reranking, and tests 5 chunking strategies (500-2000 chars). Metrics: Source Hit Rate, Keyword Hit Rate, Mean Reciprocal Rank. Run with `python evaluate.py`.
 
 ## Pages
 
 | Page | Route | Description |
 |------|-------|-------------|
-| Portfolio | `/` | Warren Buffett's current Berkshire Hathaway holdings with sector allocation chart and sortable table |
-| Chat | `/chat` | RAG chatbot with conversation history sidebar, typing animation, and source citations |
-| Trading | `/trading` | Stock analysis with price charts and fundamentals, plus strategy backtesting with equity curves |
-
-## How It Works
-
-```
-Question → Embed (MiniLM) → Search (FAISS) → Generate (FLAN-T5 or Llama 3) → Answer + Sources
-```
-
-1. **Ingestion** (`ingest.py`): Extracts text from the PDF, chunks it (1000 chars, 200 overlap), parses and deduplicates CSV Q&A pairs, embeds everything with `paraphrase-MiniLM-L6-v2`, and stores in a FAISS vector index.
-
-2. **Query** (`rag_chain.py`): Embeds the user question, retrieves the top-5 most similar chunks, and generates an answer with FLAN-T5-base (or Groq Llama 3 if API key is set).
-
-3. **API** (`server.py`): FastAPI wrapper exposing `POST /api/chat` that calls `rag_chain.ask()`.
-
-4. **UI** (`ui/`): React + Tailwind dark-themed frontend with three pages — portfolio overview, RAG chatbot, and stock trading/backtesting.
+| Portfolio | `/` | Berkshire Hathaway holdings with sector allocation chart |
+| Chat | `/chat` | RAG chatbot with conversation history, sources, stock analysis |
+| Trading | `/trading` | Fundamental analysis (12 Buffett ratios) + strategy backtesting |
 
 ## Data
 
-All source data lives in `data/`:
+In `data/`:
 
-- **PDF**: Berkshire Hathaway shareholder letters (1,010 pages)
-- **CSVs** (7 files, 996 unique Q&A pairs): Personal Life, Adaptability, Psychology, Risk Management, Strategy Development, Timing, and a clean aggregated dataset
+- **PDF**: All Berkshire Hathaway shareholder letters (1,010 pages)
+- **CSVs** (7 files, 5,992 unique Q&A pairs): Personal Life, Adaptability, Psychology, Risk Management, Strategy Development, Timing, and an aggregated investment dataset
 
 ## Project Structure
 
 ```
-├── config.py            # All settings (paths, models, parameters)
-├── ingest.py            # Data pipeline → FAISS vector index
-├── rag_chain.py         # RAG retrieval + answer generation
-├── server.py            # FastAPI backend (wraps rag_chain)
-├── app.py               # Legacy Streamlit UI
-├── requirements.txt     # Python dependencies
-├── data/                # PDF + CSV source files
-├── vectorstore/         # FAISS index (generated, gitignored)
-└── ui/                  # React frontend
-    ├── src/
-    │   ├── pages/       # HomePage, ChatPage, TradingPage
-    │   ├── components/  # Reusable UI components
-    │   ├── data/        # Mock data for trading/backtest
-    │   ├── services/    # API client
-    │   └── utils/       # Formatters
-    ├── package.json
-    └── vite.config.js
+├── config.py              # All settings (paths, models, parameters)
+├── ingest.py              # Data pipeline → FAISS + BM25 indexes
+├── retriever.py           # Hybrid search (BM25+FAISS) + cross-encoder reranking
+├── rag_chain.py           # RAG orchestration + LLM generation + conversation memory
+├── stock_analysis.py      # Live stock data + Buffett ratio analysis
+├── trading_backtest.py    # MA crossover + RSI backtesting strategies
+├── evaluate.py            # RAG evaluation + chunking comparison
+├── server.py              # FastAPI backend
+├── app.py                 # Streamlit UI (standalone alternative)
+├── requirements.txt
+├── .env.example
+├── architecture.md        # Mermaid diagrams of system architecture
+├── data/                  # PDF + CSV source files
+├── vectorstore/           # FAISS + BM25 indexes (generated, gitignored)
+└── ui/                    # React + Vite + Tailwind frontend
+    ├── src/pages/         # Portfolio, Chat, Trading pages
+    ├── src/components/    # Reusable UI components
+    └── src/services/      # API client
 ```
 
 ## Tech Stack
 
 | Component | Tool |
 |-----------|------|
-| Embeddings | sentence-transformers/paraphrase-MiniLM-L6-v2 |
-| Vector Store | FAISS |
-| Generation | FLAN-T5-base (local) / Llama 3.3-70B via Groq (optional) |
+| Embeddings | paraphrase-MiniLM-L6-v2 |
+| Vector Store | FAISS + BM25 (hybrid) |
+| Reranking | cross-encoder/ms-marco-MiniLM-L-6-v2 |
+| Generation | FLAN-T5-base (local) / Llama 3.3-70B via Groq |
 | Framework | LangChain |
+| Stock Data | Yahoo Finance (yfinance) |
+| Backtesting | Custom (MA Crossover, RSI) |
 | Backend | FastAPI + Uvicorn |
 | Frontend | React + Vite + Tailwind CSS |
-| Charts | Recharts |
+| Evaluation | Custom benchmark suite (10 questions, 3 metrics) |

--- a/app.py
+++ b/app.py
@@ -15,6 +15,8 @@ from rag_chain import ask, get_llm
 from retriever import get_vectorstore, get_reranker
 from stock_analysis import compute_ratios, passes_rule, fmt, RATIO_DEFINITIONS
 from trading_backtest import run_moving_average_crossover, run_rsi_strategy
+from evaluate import evaluate_retrieval, compare_chunk_sizes, TEST_SUITE
+from retriever import hybrid_search, retrieve
 
 # ── Page config ──────────────────────────────────────────────────────────────
 st.set_page_config(page_title=APP_TITLE, page_icon="📈", layout="wide")
@@ -57,7 +59,7 @@ with st.sidebar:
     st.caption("Data: 1,010-page PDF + 5,992 Q&A pairs across 7 datasets.")
 
 # ── Tabs ─────────────────────────────────────────────────────────────────────
-tab_chat, tab_stocks = st.tabs(["💬 Chat Bot", "📊 Stock Analysis & Backtesting"])
+tab_chat, tab_stocks, tab_eval = st.tabs(["Chat Bot", "Stock Analysis & Backtesting", "RAG Evaluation"])
 
 
 # ═══════════════════════════ TAB 1: CHAT BOT ═════════════════════════════════
@@ -427,3 +429,149 @@ with tab_stocks:
                 display_trades["Exit_Price"] = display_trades["Exit_Price"].round(2)
                 display_trades["PnL"] = display_trades["PnL"].map(lambda x: f"{x:.2%}")
                 st.dataframe(display_trades, hide_index=True, use_container_width=True)
+
+
+# ══════════════════════ TAB 3: RAG EVALUATION ════════════════════════════════
+with tab_eval:
+    st.title("RAG Evaluation Dashboard")
+    st.caption(
+        "Benchmarks retrieval quality across search methods and chunking strategies. "
+        "Shows why hybrid search + reranking outperforms FAISS alone."
+    )
+
+    # ── Section 1: Search Method Comparison ──────────────────────────────────
+    st.subheader("Search Method Comparison")
+    st.write(
+        "Compares three retrieval approaches on a suite of "
+        f"**{len(TEST_SUITE)} test questions** ranging from easy keyword matches "
+        "to paraphrased and adversarial queries."
+    )
+
+    if st.button("Run Search Evaluation", type="primary", key="run_search_eval"):
+        vs = get_vectorstore()
+
+        methods = {
+            "FAISS Only": lambda q, k: vs.similarity_search(q, k=k),
+            "Hybrid (BM25 + FAISS)": lambda q, k: hybrid_search(q, k=k),
+            "Hybrid + Reranking": lambda q, k: retrieve(q, k_retrieve=10, k_final=k),
+        }
+
+        all_metrics = {}
+        all_details = {}
+        progress = st.progress(0, text="Evaluating...")
+
+        for i, (name, fn) in enumerate(methods.items()):
+            progress.progress((i) / len(methods), text=f"Testing: {name}...")
+            metrics, details = evaluate_retrieval(fn)
+            all_metrics[name] = metrics
+            all_details[name] = details
+
+        progress.progress(1.0, text="Done!")
+        st.session_state.search_metrics = all_metrics
+        st.session_state.search_details = all_details
+
+    if "search_metrics" in st.session_state:
+        metrics = st.session_state.search_metrics
+
+        # Summary metrics
+        cols = st.columns(len(metrics))
+        for col, (name, m) in zip(cols, metrics.items()):
+            with col:
+                st.markdown(f"**{name}**")
+                st.metric("Source Hit Rate", f"{m['source_hit_rate']:.0%}")
+                st.metric("Keyword Hit Rate", f"{m['keyword_hit_rate']:.0%}")
+                st.metric("MRR", f"{m['mrr']:.3f}")
+
+        # Bar chart comparison
+        chart_data = pd.DataFrame({
+            name: {
+                "Source Hit Rate": m["source_hit_rate"] * 100,
+                "Keyword Hit Rate": m["keyword_hit_rate"] * 100,
+                "MRR": m["mrr"] * 100,
+            }
+            for name, m in metrics.items()
+        }).T
+        st.bar_chart(chart_data, height=300)
+
+        # Detailed results per question
+        if "search_details" in st.session_state:
+            with st.expander("Detailed Results Per Question"):
+                best_method = "Hybrid + Reranking"
+                details = st.session_state.search_details.get(best_method, [])
+                rows = []
+                for d in details:
+                    rows.append({
+                        "Question": d["question"][:60] + "..." if len(d["question"]) > 60 else d["question"],
+                        "Source Hit": "Pass" if d["source_hit"] else "Fail",
+                        "Keyword Hit": "Pass" if d["keyword_hit"] else "Fail",
+                        "MRR": f"{d['mrr']:.2f}",
+                        "Top Sources": ", ".join(d["top_sources"]),
+                        "Keywords Found": ", ".join(d["keywords_found"][:3]),
+                        "Keywords Missed": ", ".join(d["keywords_missed"][:3]),
+                    })
+                st.dataframe(pd.DataFrame(rows), hide_index=True, use_container_width=True)
+
+    st.divider()
+
+    # ── Section 2: Chunking Strategy Comparison ──────────────────────────────
+    st.subheader("Chunking Strategy Comparison")
+    st.write(
+        "Tests 5 different chunk size / overlap configurations to find the optimal "
+        "balance between context granularity and retrieval quality."
+    )
+
+    if st.button("Run Chunking Evaluation", type="primary", key="run_chunk_eval"):
+        with st.spinner("Building temporary indexes and evaluating (this takes ~2 minutes)..."):
+            chunk_metrics = compare_chunk_sizes()
+            st.session_state.chunk_metrics = chunk_metrics
+
+    if "chunk_metrics" in st.session_state:
+        chunk_m = st.session_state.chunk_metrics
+
+        rows = []
+        for label, m in chunk_m.items():
+            is_current = "current" in label
+            rows.append({
+                "Chunk Config": label,
+                "PDF Chunks": m["num_pdf_chunks"],
+                "Total Docs": m["num_documents"],
+                "Source Hit Rate": f"{m['source_hit_rate']:.0%}",
+                "Keyword Hit Rate": f"{m['keyword_hit_rate']:.0%}",
+                "MRR": f"{m['mrr']:.3f}",
+            })
+
+        df_chunks = pd.DataFrame(rows)
+        st.dataframe(df_chunks, hide_index=True, use_container_width=True)
+
+        # Chart
+        chart_rows = {
+            label: {
+                "Keyword Hit Rate": m["keyword_hit_rate"] * 100,
+                "MRR": m["mrr"] * 100,
+            }
+            for label, m in chunk_m.items()
+        }
+        st.bar_chart(pd.DataFrame(chart_rows).T, height=300)
+
+        # Insight
+        best_kw = max(chunk_m.items(), key=lambda x: x[1]["keyword_hit_rate"])
+        st.success(
+            f"Best chunking strategy: **{best_kw[0]}** with "
+            f"{best_kw[1]['keyword_hit_rate']:.0%} keyword hit rate and "
+            f"{best_kw[1]['mrr']:.3f} MRR."
+        )
+
+    st.divider()
+
+    # ── Section 3: Test Suite ────────────────────────────────────────────────
+    st.subheader("Test Suite")
+    st.write(f"The evaluation uses **{len(TEST_SUITE)} benchmark questions** across difficulty levels:")
+
+    rows = []
+    for t in TEST_SUITE:
+        rows.append({
+            "Question": t["question"],
+            "Expected Source": t["expected_source"],
+            "Expected Keywords": ", ".join(t["expected_keywords"][:4]),
+        })
+    st.dataframe(pd.DataFrame(rows), hide_index=True, use_container_width=True)

--- a/app.py
+++ b/app.py
@@ -11,7 +11,8 @@ import pandas as pd
 import streamlit as st
 
 from config import APP_TITLE
-from rag_chain import ask, get_vectorstore, get_llm
+from rag_chain import ask, get_llm
+from retriever import get_vectorstore, get_reranker
 from stock_analysis import compute_ratios, passes_rule, fmt, RATIO_DEFINITIONS
 from trading_backtest import run_moving_average_crossover, run_rsi_strategy
 
@@ -23,6 +24,7 @@ st.set_page_config(page_title=APP_TITLE, page_icon="📈", layout="wide")
 def load_models():
     get_vectorstore()
     get_llm()
+    get_reranker()
     return True
 
 
@@ -148,8 +150,10 @@ with tab_chat:
 
         with st.chat_message("assistant"):
             is_stock = any(kw in question.lower() for kw in ["stock", "think", "invest", "buy", "sell"])
+            # Pass conversation history for follow-up support
+            history = [{"role": m["role"], "content": m["content"]} for m in st.session_state.messages]
             with st.spinner("Analyzing..." if is_stock else "Thinking..."):
-                result = ask(question)
+                result = ask(question, history=history)
             if result.get("stock_data"):
                 display_stock_card(result["stock_data"])
             st.write(result["answer"])

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,232 @@
+
+# Architecture Diagrams
+
+## Full System Flow
+
+```mermaid
+flowchart TD
+    subgraph USER["User Interface"]
+        UI[Streamlit App<br/>app.py]
+        API[FastAPI Server<br/>server.py]
+    end
+
+    subgraph INGESTION["Offline: Data Ingestion Pipeline — ingest.py"]
+        PDF[(PDF<br/>1,010 pages<br/>Shareholder Letters)]
+        CSV[(7 CSV Files<br/>5,992 Q&A Pairs)]
+        LOADER[PyPDFLoader]
+        SPLITTER[RecursiveCharacterTextSplitter<br/>1000 chars / 200 overlap]
+        DEDUP[CSV Parser<br/>Deduplicate + Normalize]
+        EMBED_BUILD[HuggingFaceEmbeddings<br/>paraphrase-MiniLM-L6-v2]
+        FAISS_BUILD[FAISS Index Builder]
+        BM25_BUILD[BM25 Index Builder<br/>BM25Okapi]
+        FAISS_STORE[(FAISS Index<br/>vectorstore/)]
+        BM25_STORE[(BM25 Index<br/>vectorstore/bm25.pkl)]
+
+        PDF --> LOADER --> SPLITTER --> EMBED_BUILD
+        CSV --> DEDUP --> EMBED_BUILD
+        EMBED_BUILD --> FAISS_BUILD --> FAISS_STORE
+        DEDUP --> BM25_BUILD --> BM25_STORE
+        SPLITTER --> BM25_BUILD
+    end
+
+    subgraph QUERY["Online: Query Pipeline — rag_chain.py"]
+        INPUT[User Question<br/>+ Chat History]
+        STOCK_CHECK{Is Stock<br/>Query?}
+
+        subgraph RETRIEVAL["Hybrid Retrieval — retriever.py"]
+            FAISS_SEARCH[FAISS Semantic Search<br/>k=10]
+            BM25_SEARCH[BM25 Keyword Search<br/>k=10]
+            RRF[Reciprocal Rank Fusion<br/>Merge + Score]
+            RERANK[Cross-Encoder Reranker<br/>ms-marco-MiniLM-L-6-v2<br/>Top 5]
+        end
+
+        subgraph STOCK["Stock Analysis — stock_analysis.py"]
+            TICKER[Extract Ticker<br/>from Query]
+            YF[Yahoo Finance<br/>Live Financial Data]
+            RATIOS[Compute Ratios<br/>P/E, ROE, Debt, Margins]
+            BACKTEST_MA[MA Crossover Backtest<br/>20/50 SMA]
+            BACKTEST_RSI[RSI Backtest<br/>30/70 Thresholds]
+        end
+
+        PROMPT[Prompt Builder<br/>Context + History + Stock Data]
+
+        subgraph LLM["Generation"]
+            GROQ[Groq API<br/>Llama 3.3 70B]
+            FLAN[FLAN-T5-base<br/>Local / CPU]
+        end
+
+        ANSWER[Answer + Sources<br/>+ Stock Data]
+    end
+
+    UI --> INPUT
+    API --> INPUT
+    INPUT --> STOCK_CHECK
+
+    STOCK_CHECK -- Yes --> TICKER
+    TICKER --> YF
+    YF --> RATIOS
+    YF --> BACKTEST_MA
+    YF --> BACKTEST_RSI
+    RATIOS --> PROMPT
+    BACKTEST_MA --> PROMPT
+    BACKTEST_RSI --> PROMPT
+
+    STOCK_CHECK -- No --> FAISS_SEARCH
+    STOCK_CHECK -- Yes --> FAISS_SEARCH
+
+    FAISS_STORE -.-> FAISS_SEARCH
+    BM25_STORE -.-> BM25_SEARCH
+
+    FAISS_SEARCH --> RRF
+    BM25_SEARCH --> RRF
+    RRF --> RERANK
+    RERANK --> PROMPT
+
+    INPUT -.->|Chat History| PROMPT
+
+    PROMPT --> GROQ
+    PROMPT --> FLAN
+    GROQ --> ANSWER
+    FLAN --> ANSWER
+    ANSWER --> UI
+    ANSWER --> API
+```
+
+## Retrieval Pipeline Detail
+
+```mermaid
+flowchart LR
+    Q[User Query] --> HS[hybrid_search]
+
+    subgraph HS[Hybrid Search]
+        direction TB
+        FAISS[FAISS<br/>Semantic Search<br/>Embedding Similarity]
+        BM25[BM25<br/>Keyword Search<br/>Term Frequency]
+        MERGE[RRF Merge<br/>score = Σ 1/60+rank]
+        FAISS --> MERGE
+        BM25 --> MERGE
+    end
+
+    HS -->|10 candidates| RR[Cross-Encoder<br/>Reranker]
+    RR -->|Top 5| DOCS[Final Documents]
+```
+
+## Conversation Memory Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant A as App (Streamlit)
+    participant R as RAG Chain
+    participant LLM as LLM (Groq/FLAN-T5)
+
+    U->>A: "What is Buffett's view on ROE?"
+    A->>R: ask(question, history=[])
+    R->>LLM: prompt + context
+    LLM-->>R: "He views ROE as a key measure..."
+    R-->>A: answer + sources
+    A-->>U: Display answer
+
+    U->>A: "Tell me more about that"
+    A->>R: ask(question, history=[prev Q&A])
+    Note over R: Enriches short query<br/>with previous answer context
+    R->>LLM: prompt + context + chat history
+    LLM-->>R: "Building on his ROE philosophy..."
+    R-->>A: answer + sources
+    A-->>U: Display follow-up answer
+```
+
+## Stock Analysis Pipeline
+
+```mermaid
+flowchart TD
+    Q["What would Buffett<br/>think of AAPL?"] --> DETECT[is_stock_query]
+    DETECT --> EXTRACT[extract_ticker<br/>→ AAPL]
+    EXTRACT --> YF[yfinance API]
+
+    YF --> METRICS[Financial Metrics<br/>P/E, ROE, Debt/Equity<br/>Margins, Dividend Yield]
+    YF --> HIST[Price History<br/>1Y and 5Y Returns]
+    YF --> BT_MA[Backtest: MA Crossover<br/>20/50 SMA since 2018]
+    YF --> BT_RSI[Backtest: RSI Strategy<br/>30/70 since 2018]
+
+    BT_MA --> BT_RESULTS[Backtest Results<br/>Return, Sharpe, Win Rate<br/>Max Drawdown, # Trades]
+    BT_RSI --> BT_RESULTS
+
+    METRICS --> SUMMARY[Stock Summary<br/>for LLM Prompt]
+    HIST --> SUMMARY
+    BT_RESULTS --> SUMMARY
+
+    RAG[RAG Retrieval<br/>Buffett's Investment<br/>Principles] --> PROMPT[Combined Prompt]
+    SUMMARY --> PROMPT
+
+    PROMPT --> LLM[LLM Generation]
+    LLM --> ANSWER["Buffett-style<br/>Stock Analysis"]
+
+    METRICS --> CARD[Stock Metrics Card<br/>in Streamlit UI]
+    BT_RESULTS --> CARD
+```
+
+## Evaluation Pipeline
+
+```mermaid
+flowchart TD
+    EVAL[evaluate.py] --> SM[Compare Search Methods]
+    EVAL --> CS[Compare Chunk Sizes]
+
+    SM --> FAISS_ONLY[FAISS Only]
+    SM --> HYBRID[Hybrid BM25+FAISS]
+    SM --> HYBRID_RR[Hybrid + Reranking]
+
+    CS --> C500["500 / 50"]
+    CS --> C750["750 / 100"]
+    CS --> C1000["1000 / 200 ★ current"]
+    CS --> C1500["1500 / 300"]
+    CS --> C2000["2000 / 400"]
+
+    subgraph METRICS[Evaluation Metrics]
+        SHR[Source Hit Rate]
+        KHR[Keyword Hit Rate]
+        MRR[Mean Reciprocal Rank]
+    end
+
+    FAISS_ONLY --> METRICS
+    HYBRID --> METRICS
+    HYBRID_RR --> METRICS
+    C500 --> METRICS
+    C750 --> METRICS
+    C1000 --> METRICS
+    C1500 --> METRICS
+    C2000 --> METRICS
+
+    METRICS --> RESULTS[(eval_results.json)]
+```
+
+## Module Dependency Graph
+
+```mermaid
+graph TD
+    CONFIG[config.py] --> INGEST[ingest.py]
+    CONFIG --> RETRIEVER[retriever.py]
+    CONFIG --> RAG[rag_chain.py]
+    CONFIG --> STOCK[stock_analysis.py]
+    CONFIG --> APP[app.py]
+
+    RETRIEVER --> INGEST
+    RETRIEVER --> RAG
+    RETRIEVER --> EVAL[evaluate.py]
+    RETRIEVER --> APP
+
+    STOCK --> RAG
+    TRADING[trading_backtest.py] --> STOCK
+    TRADING --> APP
+
+    RAG --> APP
+    RAG --> SERVER[server.py]
+
+    INGEST --> EVAL
+
+    style CONFIG fill:#f9f,stroke:#333
+    style APP fill:#bbf,stroke:#333
+    style RAG fill:#bfb,stroke:#333
+    style RETRIEVER fill:#fbf,stroke:#333
+```

--- a/evaluate.py
+++ b/evaluate.py
@@ -23,57 +23,88 @@ from ingest import load_pdf, load_csvs
 
 RESULTS_PATH = os.path.join(VECTORSTORE_DIR, "eval_results.json")
 
-# Test suite: questions with expected source types and keywords that should appear
+# Test suite: mix of easy, paraphrased, vague, and cross-topic questions.
+# Harder questions test whether semantic search outperforms keyword search.
 TEST_SUITE = [
+    # --- Easy: direct keyword match ---
     {
         "question": "How did Buffett overcome his fear of public speaking?",
         "expected_source": "qa_personal_life",
         "expected_keywords": ["dale carnegie", "speaking", "course"],
     },
     {
-        "question": "What is Buffett's view on return on equity?",
-        "expected_source": "qa_",
-        "expected_keywords": ["return on equity", "roe", "performance"],
-    },
-    {
         "question": "What happened with Berkshire's textile operations?",
         "expected_source": "shareholder_letter",
         "expected_keywords": ["textile", "berkshire"],
     },
+    # --- Medium: paraphrased (no exact keyword match) ---
     {
-        "question": "How does Buffett manage risk?",
+        "question": "How does the Oracle of Omaha decide if a company is worth buying?",
         "expected_source": "qa_",
-        "expected_keywords": ["risk", "margin of safety", "downside"],
+        "expected_keywords": ["intrinsic value", "margin of safety", "earnings"],
     },
     {
-        "question": "Why does Buffett live in Omaha?",
+        "question": "What personality trait does Buffett say matters more than being smart?",
+        "expected_source": "qa_",
+        "expected_keywords": ["temperament", "iq", "greedy"],
+    },
+    {
+        "question": "Why did Buffett refuse to move to Wall Street?",
         "expected_source": "qa_personal_life",
-        "expected_keywords": ["omaha", "home", "simple"],
+        "expected_keywords": ["omaha", "independence", "wall street"],
     },
     {
-        "question": "What is Buffett's opinion on debt?",
+        "question": "How does Buffett feel about companies that borrow heavily?",
         "expected_source": "qa_",
-        "expected_keywords": ["debt", "leverage", "conservative"],
+        "expected_keywords": ["debt", "leverage"],
+    },
+    # --- Hard: vague or indirect, requires semantic understanding ---
+    {
+        "question": "What childhood experiences shaped Buffett's money habits?",
+        "expected_source": "qa_personal_life",
+        "expected_keywords": ["grocery", "gum", "coca-cola", "pinball", "entrepreneurial"],
     },
     {
-        "question": "How did insurance operations grow at Berkshire?",
+        "question": "How did Berkshire's float contribute to investment returns?",
         "expected_source": "shareholder_letter",
-        "expected_keywords": ["insurance", "premium", "national indemnity"],
+        "expected_keywords": ["float", "insurance", "premium", "invest"],
     },
     {
-        "question": "What is intrinsic value according to Buffett?",
+        "question": "What's the difference between price and value in Buffett's mind?",
         "expected_source": "qa_",
-        "expected_keywords": ["intrinsic value", "discount", "cash flow"],
+        "expected_keywords": ["price", "value", "intrinsic", "margin"],
     },
     {
-        "question": "How does Buffett evaluate company management?",
+        "question": "Describe how Buffett's strategy evolved after meeting Charlie Munger.",
         "expected_source": "qa_",
-        "expected_keywords": ["management", "integrity", "competent"],
+        "expected_keywords": ["munger", "quality", "wonderful company", "fair price"],
+    },
+    # --- Cross-topic: should pull from shareholder letters, not Q&A ---
+    {
+        "question": "What were Berkshire's operating earnings in the late 1970s?",
+        "expected_source": "shareholder_letter",
+        "expected_keywords": ["operating earnings", "1977", "1978", "equity capital"],
     },
     {
-        "question": "What is Buffett's approach to market timing?",
+        "question": "Which insurance companies did Berkshire acquire?",
+        "expected_source": "shareholder_letter",
+        "expected_keywords": ["national indemnity", "geico", "general re", "insurance"],
+    },
+    # --- Adversarial: terms that could mislead keyword search ---
+    {
+        "question": "Does Buffett believe in diversification?",
         "expected_source": "qa_",
-        "expected_keywords": ["timing", "patience", "long-term"],
+        "expected_keywords": ["concentrate", "focus", "few", "outstanding"],
+    },
+    {
+        "question": "What role does doing nothing play in Buffett's strategy?",
+        "expected_source": "qa_",
+        "expected_keywords": ["patience", "long-term", "hold", "inactivity"],
+    },
+    {
+        "question": "How does Buffett think about competitive advantages?",
+        "expected_source": "qa_",
+        "expected_keywords": ["moat", "competitive advantage", "durable"],
     },
 ]
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,0 +1,277 @@
+"""
+evaluate.py -- RAG Evaluation & Chunking Strategy Comparison.
+
+Measures retrieval precision and answer quality across a test suite.
+Also compares different chunking strategies to show their impact on retrieval.
+
+Run standalone:  python evaluate.py
+"""
+
+import time
+import json
+import os
+
+from langchain_community.document_loaders import PyPDFLoader
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_community.vectorstores import FAISS
+from langchain_huggingface import HuggingFaceEmbeddings
+from sentence_transformers import CrossEncoder
+
+from config import PDF_PATH, CSV_FILES, EMBEDDING_MODEL, VECTORSTORE_DIR
+from retriever import retrieve, get_vectorstore, hybrid_search, get_reranker
+from ingest import load_pdf, load_csvs
+
+RESULTS_PATH = os.path.join(VECTORSTORE_DIR, "eval_results.json")
+
+# Test suite: questions with expected source types and keywords that should appear
+TEST_SUITE = [
+    {
+        "question": "How did Buffett overcome his fear of public speaking?",
+        "expected_source": "qa_personal_life",
+        "expected_keywords": ["dale carnegie", "speaking", "course"],
+    },
+    {
+        "question": "What is Buffett's view on return on equity?",
+        "expected_source": "qa_",
+        "expected_keywords": ["return on equity", "roe", "performance"],
+    },
+    {
+        "question": "What happened with Berkshire's textile operations?",
+        "expected_source": "shareholder_letter",
+        "expected_keywords": ["textile", "berkshire"],
+    },
+    {
+        "question": "How does Buffett manage risk?",
+        "expected_source": "qa_",
+        "expected_keywords": ["risk", "margin of safety", "downside"],
+    },
+    {
+        "question": "Why does Buffett live in Omaha?",
+        "expected_source": "qa_personal_life",
+        "expected_keywords": ["omaha", "home", "simple"],
+    },
+    {
+        "question": "What is Buffett's opinion on debt?",
+        "expected_source": "qa_",
+        "expected_keywords": ["debt", "leverage", "conservative"],
+    },
+    {
+        "question": "How did insurance operations grow at Berkshire?",
+        "expected_source": "shareholder_letter",
+        "expected_keywords": ["insurance", "premium", "national indemnity"],
+    },
+    {
+        "question": "What is intrinsic value according to Buffett?",
+        "expected_source": "qa_",
+        "expected_keywords": ["intrinsic value", "discount", "cash flow"],
+    },
+    {
+        "question": "How does Buffett evaluate company management?",
+        "expected_source": "qa_",
+        "expected_keywords": ["management", "integrity", "competent"],
+    },
+    {
+        "question": "What is Buffett's approach to market timing?",
+        "expected_source": "qa_",
+        "expected_keywords": ["timing", "patience", "long-term"],
+    },
+]
+
+
+def evaluate_retrieval(search_fn, test_suite=TEST_SUITE, k=5):
+    """
+    Evaluate retrieval quality across a test suite.
+
+    Metrics:
+    - Source Hit Rate: % of queries where the expected source type appears in top-k
+    - Keyword Hit Rate: % of queries where expected keywords appear in retrieved docs
+    - Mean Reciprocal Rank (MRR): avg of 1/rank of first relevant result
+    """
+    source_hits = 0
+    keyword_hits = 0
+    reciprocal_ranks = []
+
+    results = []
+
+    for test in test_suite:
+        q = test["question"]
+        expected_src = test["expected_source"]
+        expected_kw = test["expected_keywords"]
+
+        docs = search_fn(q, k)
+
+        # Source hit: is the expected source in any of the top-k results?
+        sources = [doc.metadata.get("source", "") for doc in docs]
+        source_hit = any(expected_src in s for s in sources)
+        if source_hit:
+            source_hits += 1
+
+        # Find rank of first source hit
+        first_rank = None
+        for i, s in enumerate(sources):
+            if expected_src in s:
+                first_rank = i + 1
+                break
+        reciprocal_ranks.append(1.0 / first_rank if first_rank else 0.0)
+
+        # Keyword hit: do any expected keywords appear in retrieved content?
+        all_content = " ".join(doc.page_content.lower() for doc in docs)
+        kw_found = [kw for kw in expected_kw if kw.lower() in all_content]
+        keyword_hit = len(kw_found) > 0
+        if keyword_hit:
+            keyword_hits += 1
+
+        results.append({
+            "question": q,
+            "source_hit": source_hit,
+            "keyword_hit": keyword_hit,
+            "keywords_found": kw_found,
+            "keywords_missed": [kw for kw in expected_kw if kw.lower() not in all_content],
+            "mrr": reciprocal_ranks[-1],
+            "top_sources": sources[:3],
+        })
+
+    n = len(test_suite)
+    metrics = {
+        "source_hit_rate": source_hits / n,
+        "keyword_hit_rate": keyword_hits / n,
+        "mrr": sum(reciprocal_ranks) / n,
+        "num_questions": n,
+    }
+
+    return metrics, results
+
+
+def compare_search_methods():
+    """Compare FAISS-only, BM25+FAISS hybrid, and hybrid+reranking."""
+    print("Evaluating search methods...\n")
+
+    vs = get_vectorstore()
+
+    # Method 1: FAISS only
+    def faiss_search(q, k):
+        return vs.similarity_search(q, k=k)
+
+    # Method 2: Hybrid (BM25 + FAISS)
+    def hybrid_only(q, k):
+        return hybrid_search(q, k=k)
+
+    # Method 3: Hybrid + Reranking
+    def hybrid_reranked(q, k):
+        return retrieve(q, k_retrieve=10, k_final=k)
+
+    methods = {
+        "FAISS Only": faiss_search,
+        "Hybrid (BM25 + FAISS)": hybrid_only,
+        "Hybrid + Reranking": hybrid_reranked,
+    }
+
+    all_metrics = {}
+    for name, fn in methods.items():
+        print(f"  Testing: {name}...")
+        metrics, _ = evaluate_retrieval(fn)
+        all_metrics[name] = metrics
+        print(f"    Source Hit Rate: {metrics['source_hit_rate']:.0%}")
+        print(f"    Keyword Hit Rate: {metrics['keyword_hit_rate']:.0%}")
+        print(f"    MRR: {metrics['mrr']:.3f}")
+
+    return all_metrics
+
+
+def compare_chunk_sizes():
+    """
+    Compare different chunking strategies by building temporary indexes
+    and measuring retrieval quality on each.
+    """
+    print("\nComparing chunking strategies...\n")
+
+    chunk_configs = [
+        {"size": 500, "overlap": 50, "label": "500 / 50"},
+        {"size": 750, "overlap": 100, "label": "750 / 100"},
+        {"size": 1000, "overlap": 200, "label": "1000 / 200 (current)"},
+        {"size": 1500, "overlap": 300, "label": "1500 / 300"},
+        {"size": 2000, "overlap": 400, "label": "2000 / 400"},
+    ]
+
+    embeddings = HuggingFaceEmbeddings(model_name=EMBEDDING_MODEL)
+    csv_docs = load_csvs()
+
+    # Load PDF pages once
+    loader = PyPDFLoader(PDF_PATH)
+    pages = loader.load()
+
+    all_metrics = {}
+
+    for cfg in chunk_configs:
+        label = cfg["label"]
+        print(f"  Testing chunk size: {label}...")
+
+        splitter = RecursiveCharacterTextSplitter(
+            chunk_size=cfg["size"],
+            chunk_overlap=cfg["overlap"],
+        )
+        pdf_chunks = splitter.split_documents(pages)
+        for chunk in pdf_chunks:
+            chunk.metadata["source"] = "shareholder_letter"
+
+        all_docs = pdf_chunks + csv_docs
+        print(f"    Documents: {len(all_docs)} ({len(pdf_chunks)} PDF chunks + {len(csv_docs)} Q&A)")
+
+        # Build temporary FAISS index
+        vs = FAISS.from_documents(all_docs, embeddings)
+
+        def search_fn(q, k):
+            return vs.similarity_search(q, k=k)
+
+        metrics, _ = evaluate_retrieval(search_fn)
+        metrics["num_documents"] = len(all_docs)
+        metrics["num_pdf_chunks"] = len(pdf_chunks)
+        all_metrics[label] = metrics
+
+        print(f"    Source Hit Rate: {metrics['source_hit_rate']:.0%}")
+        print(f"    Keyword Hit Rate: {metrics['keyword_hit_rate']:.0%}")
+        print(f"    MRR: {metrics['mrr']:.3f}")
+
+    return all_metrics
+
+
+def run_full_evaluation():
+    """Run all evaluations and save results."""
+    print("=" * 60)
+    print("RAG EVALUATION SUITE")
+    print("=" * 60)
+
+    start = time.time()
+
+    # Compare search methods
+    search_metrics = compare_search_methods()
+
+    # Compare chunk sizes
+    chunk_metrics = compare_chunk_sizes()
+
+    # Detailed results for the best method (hybrid + reranking)
+    _, detailed_results = evaluate_retrieval(
+        lambda q, k: retrieve(q, k_retrieve=10, k_final=k)
+    )
+
+    elapsed = time.time() - start
+
+    results = {
+        "search_methods": search_metrics,
+        "chunk_sizes": chunk_metrics,
+        "detailed_results": detailed_results,
+        "elapsed_seconds": elapsed,
+    }
+
+    os.makedirs(VECTORSTORE_DIR, exist_ok=True)
+    with open(RESULTS_PATH, "w") as f:
+        json.dump(results, f, indent=2, default=str)
+
+    print(f"\nResults saved to {RESULTS_PATH}")
+    print(f"Total evaluation time: {elapsed:.1f} seconds")
+
+    return results
+
+
+if __name__ == "__main__":
+    run_full_evaluation()

--- a/ingest.py
+++ b/ingest.py
@@ -21,6 +21,7 @@ from config import (
     PDF_PATH, CSV_FILES, VECTORSTORE_DIR,
     CHUNK_SIZE, CHUNK_OVERLAP, EMBEDDING_MODEL,
 )
+from retriever import build_bm25_index
 
 
 def load_pdf():
@@ -102,6 +103,9 @@ def main():
     embeddings = HuggingFaceEmbeddings(model_name=EMBEDDING_MODEL)
     vectorstore = FAISS.from_documents(all_docs, embeddings)
     vectorstore.save_local(VECTORSTORE_DIR)
+
+    print("Building BM25 keyword index...")
+    build_bm25_index(all_docs)
 
     elapsed = time.time() - start
     print(f"\nVector store saved to {VECTORSTORE_DIR}/")

--- a/rag_chain.py
+++ b/rag_chain.py
@@ -1,38 +1,28 @@
 """
 rag_chain.py -- RAG retrieval and generation pipeline.
 
-Loads the FAISS vector store, retrieves relevant chunks for a user question,
-and generates an answer using FLAN-T5 (local) or Groq Llama 3 (if API key is set).
+Features:
+- Hybrid search (BM25 + FAISS) with cross-encoder reranking
+- Conversation memory for follow-up questions
+- Stock analysis with live data + backtesting
+- FLAN-T5 (local) or Groq Llama 3 generation
 """
 
 import os
 
 from dotenv import load_dotenv
-from langchain_community.vectorstores import FAISS
-from langchain_huggingface import HuggingFaceEmbeddings
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
 
 from config import VECTORSTORE_DIR, EMBEDDING_MODEL, LOCAL_MODEL, GROQ_MODEL, TOP_K
+from retriever import retrieve, get_vectorstore, get_reranker
 from stock_analysis import is_stock_query, extract_ticker, fetch_stock_data, format_stock_summary
 
 load_dotenv()
 
-# Module-level singletons (loaded once, reused across calls)
-_vectorstore = None
+# Module-level singletons
 _model = None
 _tokenizer = None
 _groq_client = None
-
-
-def get_vectorstore():
-    """Load the FAISS vector store (cached after first call)."""
-    global _vectorstore
-    if _vectorstore is None:
-        embeddings = HuggingFaceEmbeddings(model_name=EMBEDDING_MODEL)
-        _vectorstore = FAISS.load_local(
-            VECTORSTORE_DIR, embeddings, allow_dangerous_deserialization=True
-        )
-    return _vectorstore
 
 
 def get_llm():
@@ -66,17 +56,35 @@ def build_context(docs):
     return "\n\n".join(context_parts)
 
 
-def build_groq_prompt(question, context):
-    """Build the detailed prompt for Groq Llama 3 (from teammate's rag_chat.py)."""
+def format_chat_history(history):
+    """Format conversation history for the prompt."""
+    if not history:
+        return ""
+    lines = []
+    for msg in history[-4:]:  # last 4 messages (2 turns)
+        role = "User" if msg["role"] == "user" else "Assistant"
+        lines.append(f"{role}: {msg['content']}")
+    return "\n".join(lines)
+
+
+def build_groq_prompt(question, context, chat_history=""):
+    """Build the detailed prompt for Groq."""
+    history_block = ""
+    if chat_history:
+        history_block = f"""
+Previous conversation:
+{chat_history}
+
+"""
     return f"""You are a Warren Buffett trader/investor chatbot built from team-prepared study material.
 Answer the user's question using ONLY the retrieved context below.
-
-Rules:
+{history_block}Rules:
 - Do not mention "Context 1", "Context 2", or similar references.
 - Do not say "according to the context".
 - Give a direct, natural answer.
 - Prefer 2-4 sentences.
 - Be specific when the dataset supports specifics.
+- If this is a follow-up question, use the conversation history to understand what the user is referring to.
 - If the question asks how Buffett adapted or evolved, prioritize concrete historical changes in his strategy (e.g., shift from buying cheap stocks to high-quality businesses) if present in the context.
 - Avoid vague summaries like "he learned from experience" unless no more specific answer is available.
 - If the answer is not clearly supported by the retrieved material, say:
@@ -138,11 +146,15 @@ def build_local_prompt(question, context):
     )
 
 
-def ask(question):
+def ask(question, history=None):
     """
     Retrieve relevant chunks and generate an answer.
-    If the question is about a specific stock, fetch real market data
-    and analyze it through Buffett's investment principles.
+    Uses hybrid search (BM25 + FAISS) with cross-encoder reranking.
+    Supports conversation memory via the history parameter.
+
+    Args:
+        question: The user's question
+        history: List of {"role": "user"|"assistant", "content": str} dicts
 
     Returns:
         dict with keys:
@@ -150,7 +162,6 @@ def ask(question):
             - "sources": list of dicts with "content", "source", "page" keys
             - "stock_data": dict of stock metrics (only if stock query)
     """
-    vectorstore = get_vectorstore()
     model, tokenizer, groq_client = get_llm()
 
     # Check if this is a stock analysis query
@@ -163,21 +174,30 @@ def ask(question):
             if stock_data:
                 stock_summary = format_stock_summary(stock_data)
 
-    # Retrieve Buffett's principles -- use investment-focused search for stock queries
+    # Retrieve with hybrid search + reranking
     if stock_data:
         search_query = "investment criteria value investing margin of safety return on equity"
-        docs = vectorstore.similarity_search(search_query, k=TOP_K)
     else:
-        docs = vectorstore.similarity_search(question, k=TOP_K)
+        # For follow-ups, enrich the query with context from history
+        search_query = question
+        if history:
+            last_assistant = [m for m in history if m["role"] == "assistant"]
+            if last_assistant and len(question.split()) < 8:
+                # Short question likely a follow-up, add context
+                search_query = f"{last_assistant[-1]['content'][:200]} {question}"
 
+    docs = retrieve(search_query, k_retrieve=10, k_final=TOP_K)
     context = build_context(docs)
+
+    # Format chat history for conversation memory
+    chat_history = format_chat_history(history) if history else ""
 
     # Generate answer
     if groq_client is not None:
         if stock_data and stock_summary:
             prompt = build_stock_groq_prompt(question, context, stock_summary)
         else:
-            prompt = build_groq_prompt(question, context)
+            prompt = build_groq_prompt(question, context, chat_history)
         response = groq_client.chat.completions.create(
             model=GROQ_MODEL,
             messages=[{"role": "user", "content": prompt}],

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ uvicorn[standard]>=0.30.0
 yfinance>=0.2.0
 matplotlib>=3.8.0
 numpy>=1.26.0
+rank_bm25>=0.2.0

--- a/retriever.py
+++ b/retriever.py
@@ -1,0 +1,149 @@
+"""
+retriever.py -- Hybrid search (BM25 + FAISS) with cross-encoder reranking.
+
+Combines keyword-based BM25 retrieval with FAISS semantic search using
+Reciprocal Rank Fusion (RRF), then reranks the merged results with a
+cross-encoder model for higher precision.
+"""
+
+import os
+import re
+import pickle
+
+from rank_bm25 import BM25Okapi
+from sentence_transformers import CrossEncoder
+from langchain_community.vectorstores import FAISS
+from langchain_huggingface import HuggingFaceEmbeddings
+
+from config import VECTORSTORE_DIR, EMBEDDING_MODEL
+
+# Singletons
+_vectorstore = None
+_bm25_index = None
+_bm25_docs = None
+_reranker = None
+
+BM25_PATH = os.path.join(VECTORSTORE_DIR, "bm25.pkl")
+RERANKER_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+
+def tokenize(text):
+    """Simple whitespace + lowercase tokenizer for BM25."""
+    return re.findall(r'\w+', text.lower())
+
+
+def get_vectorstore():
+    """Load the FAISS vector store."""
+    global _vectorstore
+    if _vectorstore is None:
+        embeddings = HuggingFaceEmbeddings(model_name=EMBEDDING_MODEL)
+        _vectorstore = FAISS.load_local(
+            VECTORSTORE_DIR, embeddings, allow_dangerous_deserialization=True
+        )
+    return _vectorstore
+
+
+def get_bm25():
+    """Load the BM25 index and document list."""
+    global _bm25_index, _bm25_docs
+    if _bm25_index is None:
+        with open(BM25_PATH, "rb") as f:
+            data = pickle.load(f)
+        _bm25_index = data["bm25"]
+        _bm25_docs = data["docs"]
+    return _bm25_index, _bm25_docs
+
+
+def get_reranker():
+    """Load the cross-encoder reranker model."""
+    global _reranker
+    if _reranker is None:
+        print(f"Loading reranker: {RERANKER_MODEL}...")
+        _reranker = CrossEncoder(RERANKER_MODEL)
+        print("Reranker loaded.")
+    return _reranker
+
+
+def build_bm25_index(documents):
+    """Build and save a BM25 index from a list of LangChain Documents."""
+    corpus = [tokenize(doc.page_content) for doc in documents]
+    bm25 = BM25Okapi(corpus)
+
+    os.makedirs(VECTORSTORE_DIR, exist_ok=True)
+    with open(BM25_PATH, "wb") as f:
+        pickle.dump({"bm25": bm25, "docs": documents}, f)
+
+    print(f"BM25 index saved to {BM25_PATH} ({len(documents)} documents)")
+    return bm25
+
+
+def hybrid_search(query, k=10):
+    """
+    Combine FAISS semantic search and BM25 keyword search
+    using Reciprocal Rank Fusion (RRF).
+    """
+    vectorstore = get_vectorstore()
+    bm25, bm25_docs = get_bm25()
+
+    # FAISS semantic search
+    faiss_results = vectorstore.similarity_search(query, k=k)
+
+    # BM25 keyword search
+    query_tokens = tokenize(query)
+    bm25_scores = bm25.get_scores(query_tokens)
+    bm25_top_indices = bm25_scores.argsort()[-k:][::-1]
+    bm25_results = [bm25_docs[i] for i in bm25_top_indices if bm25_scores[i] > 0]
+
+    # Reciprocal Rank Fusion
+    rrf_scores = {}
+    rrf_constant = 60  # standard RRF constant
+
+    for rank, doc in enumerate(faiss_results):
+        doc_id = id(doc)
+        rrf_scores[doc_id] = rrf_scores.get(doc_id, 0) + 1.0 / (rrf_constant + rank + 1)
+
+    # For BM25, we need to match by content since they're different objects
+    content_to_faiss = {doc.page_content: doc for doc in faiss_results}
+    merged_docs = {id(doc): doc for doc in faiss_results}
+
+    for rank, doc in enumerate(bm25_results):
+        # Check if this doc is already in FAISS results (by content match)
+        if doc.page_content in content_to_faiss:
+            existing = content_to_faiss[doc.page_content]
+            doc_id = id(existing)
+        else:
+            doc_id = id(doc)
+            merged_docs[doc_id] = doc
+
+        rrf_scores[doc_id] = rrf_scores.get(doc_id, 0) + 1.0 / (rrf_constant + rank + 1)
+
+    # Sort by RRF score
+    sorted_ids = sorted(rrf_scores, key=rrf_scores.get, reverse=True)
+    results = [merged_docs[doc_id] for doc_id in sorted_ids if doc_id in merged_docs]
+
+    return results[:k]
+
+
+def rerank(query, docs, top_n=5):
+    """Rerank documents using a cross-encoder model."""
+    if not docs:
+        return docs
+
+    reranker = get_reranker()
+
+    # Score each (query, document) pair
+    pairs = [(query, doc.page_content) for doc in docs]
+    scores = reranker.predict(pairs)
+
+    # Sort by score descending
+    scored_docs = sorted(zip(scores, docs), key=lambda x: x[0], reverse=True)
+    return [doc for _, doc in scored_docs[:top_n]]
+
+
+def retrieve(query, k_retrieve=10, k_final=5):
+    """
+    Full retrieval pipeline: hybrid search -> rerank -> top results.
+    """
+    candidates = hybrid_search(query, k=k_retrieve)
+    reranked = rerank(query, candidates, top_n=k_final)
+    return reranked

--- a/server.py
+++ b/server.py
@@ -252,3 +252,44 @@ def chat(req: QuestionRequest):
     from rag_chain import ask
 
     return ask(req.question)
+
+
+@app.get("/api/evaluation/search-methods")
+def eval_search_methods():
+    """Run evaluation comparing FAISS-only, Hybrid, and Hybrid+Reranking."""
+    from evaluate import evaluate_retrieval, TEST_SUITE
+    from retriever import get_vectorstore, hybrid_search, retrieve
+
+    vs = get_vectorstore()
+
+    methods = {
+        "FAISS Only": lambda q, k: vs.similarity_search(q, k=k),
+        "Hybrid (BM25 + FAISS)": lambda q, k: hybrid_search(q, k=k),
+        "Hybrid + Reranking": lambda q, k: retrieve(q, k_retrieve=10, k_final=k),
+    }
+
+    results = {}
+    for name, fn in methods.items():
+        metrics, details = evaluate_retrieval(fn)
+        results[name] = {
+            "metrics": metrics,
+            "details": details,
+        }
+
+    return results
+
+
+@app.get("/api/evaluation/chunk-sizes")
+def eval_chunk_sizes():
+    """Run evaluation comparing different chunking strategies."""
+    from evaluate import compare_chunk_sizes
+
+    return compare_chunk_sizes()
+
+
+@app.get("/api/evaluation/test-suite")
+def eval_test_suite():
+    """Return the test suite used for evaluation."""
+    from evaluate import TEST_SUITE
+
+    return TEST_SUITE

--- a/server.py
+++ b/server.py
@@ -18,8 +18,14 @@ app.add_middleware(
 )
 
 
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
 class QuestionRequest(BaseModel):
     question: str
+    history: list[ChatMessage] = []
 
 
 PORTFOLIO_TICKERS = ["AAPL", "BAC", "AXP", "KO", "CVX", "OXY", "KHC", "MCO", "DVA", "VRSN"]
@@ -251,7 +257,8 @@ def buffett_analysis(req: BuffettAnalysisRequest):
 def chat(req: QuestionRequest):
     from rag_chain import ask
 
-    return ask(req.question)
+    history = [{"role": m.role, "content": m.content} for m in req.history]
+    return ask(req.question, history=history)
 
 
 @app.get("/api/evaluation/search-methods")

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -59,7 +59,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -267,6 +266,27 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -820,6 +840,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
@@ -1221,7 +1262,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1274,7 +1314,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1383,7 +1422,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1744,7 +1782,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2733,7 +2770,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2794,7 +2830,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2804,7 +2839,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2824,7 +2858,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -2915,8 +2948,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -3200,7 +3232,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3325,7 +3356,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -6,6 +6,7 @@ import PageLayout from "./components/layout/PageLayout";
 import HomePage from "./pages/HomePage";
 import ChatPage from "./pages/ChatPage";
 import TradingPage from "./pages/TradingPage";
+import EvaluationPage from "./pages/EvaluationPage";
 
 export default function App() {
   const [loading, setLoading] = useState(true);
@@ -19,6 +20,7 @@ export default function App() {
             <Route path="/" element={<HomePage />} />
             <Route path="/chat" element={<ChatPage />} />
             <Route path="/trading" element={<TradingPage />} />
+            <Route path="/evaluation" element={<EvaluationPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </PageLayout>

--- a/ui/src/components/layout/Navbar.jsx
+++ b/ui/src/components/layout/Navbar.jsx
@@ -1,5 +1,5 @@
 import { NavLink } from "react-router-dom";
-import { BarChart3, MessageSquare, TrendingUp, Sun, Moon } from "lucide-react";
+import { BarChart3, MessageSquare, TrendingUp, FlaskConical, Sun, Moon } from "lucide-react";
 import { useTheme } from "../../context/ThemeContext";
 import warrenLogo from "../../assets/warren-logo.png";
 
@@ -7,6 +7,7 @@ const links = [
   { to: "/", label: "Portfolio", icon: BarChart3 },
   { to: "/chat", label: "Chat", icon: MessageSquare },
   { to: "/trading", label: "Trading", icon: TrendingUp },
+  { to: "/evaluation", label: "Evaluation", icon: FlaskConical },
 ];
 
 export default function Navbar() {

--- a/ui/src/pages/ChatPage.jsx
+++ b/ui/src/pages/ChatPage.jsx
@@ -136,7 +136,9 @@ export default function ChatPage() {
     setLoading(true);
 
     try {
-      const result = await sendMessage(question);
+      const currentConv = conversations.find((c) => c.id === currentId);
+      const history = (currentConv?.messages || []).map(({ role, content }) => ({ role, content }));
+      const result = await sendMessage(question, history);
       const assistantMsg = {
         role: 'assistant',
         content: result.answer,

--- a/ui/src/pages/EvaluationPage.jsx
+++ b/ui/src/pages/EvaluationPage.jsx
@@ -1,0 +1,365 @@
+import { useState, useEffect } from "react";
+import { Loader2 } from "lucide-react";
+import { fetchSearchMethodEval, fetchChunkSizeEval, fetchTestSuite } from "../services/api";
+
+function MetricCard({ label, value, highlight }) {
+  return (
+    <div className={`rounded-xl border p-4 text-center ${
+      highlight
+        ? "border-green-300 bg-green-50 dark:border-green-800 dark:bg-green-950/30"
+        : "border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800"
+    }`}>
+      <p className="text-xs font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400">
+        {label}
+      </p>
+      <p className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function BarComparison({ data, metricKey, label, formatFn }) {
+  const maxVal = Math.max(...data.map((d) => d[metricKey]));
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium text-slate-700 dark:text-slate-300">{label}</p>
+      {data.map((d) => (
+        <div key={d.name} className="flex items-center gap-3">
+          <span className="w-44 shrink-0 text-right text-xs text-slate-500 dark:text-slate-400">
+            {d.name}
+          </span>
+          <div className="flex-1">
+            <div className="h-6 rounded bg-slate-100 dark:bg-slate-700">
+              <div
+                className="flex h-6 items-center rounded bg-red-500/80 px-2 text-xs font-medium text-white transition-all duration-500"
+                style={{ width: `${(d[metricKey] / maxVal) * 100}%` }}
+              >
+                {formatFn ? formatFn(d[metricKey]) : d[metricKey]}
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function EvaluationPage() {
+  const [searchResults, setSearchResults] = useState(null);
+  const [chunkResults, setChunkResults] = useState(null);
+  const [testSuite, setTestSuite] = useState(null);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [chunkLoading, setChunkLoading] = useState(false);
+
+  useEffect(() => {
+    fetchTestSuite().then(setTestSuite).catch(console.error);
+  }, []);
+
+  const runSearchEval = async () => {
+    setSearchLoading(true);
+    try {
+      const data = await fetchSearchMethodEval();
+      setSearchResults(data);
+    } catch (e) {
+      console.error(e);
+    }
+    setSearchLoading(false);
+  };
+
+  const runChunkEval = async () => {
+    setChunkLoading(true);
+    try {
+      const data = await fetchChunkSizeEval();
+      setChunkResults(data);
+    } catch (e) {
+      console.error(e);
+    }
+    setChunkLoading(false);
+  };
+
+  const fmtPct = (v) => `${(v * 100).toFixed(0)}%`;
+  const fmtMrr = (v) => v.toFixed(3);
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-10 px-6 py-10">
+      {/* Header */}
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
+          RAG Evaluation Dashboard
+        </h1>
+        <p className="mt-2 text-slate-500 dark:text-slate-400">
+          Benchmarks retrieval quality across search methods and chunking strategies.
+          Demonstrates why hybrid search with cross-encoder reranking outperforms FAISS alone.
+        </p>
+      </div>
+
+      {/* Section 1: Search Method Comparison */}
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+              Search Method Comparison
+            </h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Compares FAISS-only, hybrid (BM25 + FAISS), and hybrid + cross-encoder reranking
+              on {testSuite ? testSuite.length : "..."} test questions.
+            </p>
+          </div>
+          <button
+            onClick={runSearchEval}
+            disabled={searchLoading}
+            className="flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-red-700 disabled:opacity-50"
+          >
+            {searchLoading && <Loader2 size={16} className="animate-spin" />}
+            {searchLoading ? "Evaluating..." : "Run Evaluation"}
+          </button>
+        </div>
+
+        {searchResults && (
+          <div className="space-y-6">
+            {/* Metric cards per method */}
+            <div className="grid gap-6 md:grid-cols-3">
+              {Object.entries(searchResults).map(([name, { metrics }]) => {
+                const isBest = name === "Hybrid + Reranking";
+                return (
+                  <div
+                    key={name}
+                    className={`space-y-3 rounded-xl border p-5 ${
+                      isBest
+                        ? "border-green-300 bg-green-50/50 dark:border-green-800 dark:bg-green-950/20"
+                        : "border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800"
+                    }`}
+                  >
+                    <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                      {name}
+                      {isBest && (
+                        <span className="ml-2 text-xs font-normal text-green-600 dark:text-green-400">
+                          (recommended)
+                        </span>
+                      )}
+                    </h3>
+                    <div className="grid grid-cols-3 gap-2">
+                      <MetricCard label="Source Hit" value={fmtPct(metrics.source_hit_rate)} highlight={metrics.source_hit_rate === 1} />
+                      <MetricCard label="Keyword Hit" value={fmtPct(metrics.keyword_hit_rate)} highlight={metrics.keyword_hit_rate >= 0.9} />
+                      <MetricCard label="MRR" value={fmtMrr(metrics.mrr)} highlight={metrics.mrr >= 0.95} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Bar charts */}
+            <div className="grid gap-6 md:grid-cols-3">
+              {(() => {
+                const barData = Object.entries(searchResults).map(([name, { metrics }]) => ({
+                  name,
+                  sourceHit: metrics.source_hit_rate * 100,
+                  keywordHit: metrics.keyword_hit_rate * 100,
+                  mrr: metrics.mrr * 100,
+                }));
+                return (
+                  <>
+                    <BarComparison data={barData} metricKey="sourceHit" label="Source Hit Rate (%)" formatFn={(v) => `${v.toFixed(0)}%`} />
+                    <BarComparison data={barData} metricKey="keywordHit" label="Keyword Hit Rate (%)" formatFn={(v) => `${v.toFixed(0)}%`} />
+                    <BarComparison data={barData} metricKey="mrr" label="Mean Reciprocal Rank (%)" formatFn={(v) => `${v.toFixed(1)}%`} />
+                  </>
+                );
+              })()}
+            </div>
+
+            {/* Detailed results table */}
+            <div className="rounded-xl border border-slate-200 dark:border-slate-700">
+              <div className="border-b border-slate-200 px-5 py-3 dark:border-slate-700">
+                <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  Per-Question Results (Hybrid + Reranking)
+                </h3>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-left text-sm">
+                  <thead className="bg-slate-50 text-xs uppercase text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+                    <tr>
+                      <th className="px-4 py-3">Question</th>
+                      <th className="px-4 py-3 text-center">Source</th>
+                      <th className="px-4 py-3 text-center">Keywords</th>
+                      <th className="px-4 py-3 text-center">MRR</th>
+                      <th className="px-4 py-3">Found</th>
+                      <th className="px-4 py-3">Missed</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
+                    {searchResults["Hybrid + Reranking"]?.details.map((d, i) => (
+                      <tr key={i} className="hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                        <td className="max-w-xs truncate px-4 py-2.5 text-slate-700 dark:text-slate-300">
+                          {d.question}
+                        </td>
+                        <td className="px-4 py-2.5 text-center">
+                          <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${
+                            d.source_hit
+                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                              : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                          }`}>
+                            {d.source_hit ? "Pass" : "Fail"}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2.5 text-center">
+                          <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${
+                            d.keyword_hit
+                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                              : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                          }`}>
+                            {d.keyword_hit ? "Pass" : "Fail"}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2.5 text-center text-slate-600 dark:text-slate-400">
+                          {d.mrr.toFixed(2)}
+                        </td>
+                        <td className="px-4 py-2.5 text-xs text-green-600 dark:text-green-400">
+                          {d.keywords_found.slice(0, 3).join(", ")}
+                        </td>
+                        <td className="px-4 py-2.5 text-xs text-red-500 dark:text-red-400">
+                          {d.keywords_missed.slice(0, 3).join(", ") || "--"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Section 2: Chunking Strategy Comparison */}
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+              Chunking Strategy Comparison
+            </h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Tests 5 chunk size / overlap configurations to find the optimal balance between
+              context granularity and retrieval quality.
+            </p>
+          </div>
+          <button
+            onClick={runChunkEval}
+            disabled={chunkLoading}
+            className="flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-red-700 disabled:opacity-50"
+          >
+            {chunkLoading && <Loader2 size={16} className="animate-spin" />}
+            {chunkLoading ? "Evaluating (~2 min)..." : "Run Evaluation"}
+          </button>
+        </div>
+
+        {chunkResults && (
+          <div className="space-y-4">
+            <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-slate-700">
+              <table className="w-full text-left text-sm">
+                <thead className="bg-slate-50 text-xs uppercase text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+                  <tr>
+                    <th className="px-4 py-3">Chunk Config</th>
+                    <th className="px-4 py-3 text-right">PDF Chunks</th>
+                    <th className="px-4 py-3 text-right">Total Docs</th>
+                    <th className="px-4 py-3 text-center">Source Hit</th>
+                    <th className="px-4 py-3 text-center">Keyword Hit</th>
+                    <th className="px-4 py-3 text-center">MRR</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
+                  {Object.entries(chunkResults).map(([label, m]) => {
+                    const isCurrent = label.includes("current");
+                    const bestKw = Math.max(...Object.values(chunkResults).map((x) => x.keyword_hit_rate));
+                    const isBestKw = m.keyword_hit_rate === bestKw;
+                    return (
+                      <tr
+                        key={label}
+                        className={
+                          isCurrent
+                            ? "bg-green-50/50 dark:bg-green-950/20"
+                            : "hover:bg-slate-50 dark:hover:bg-slate-800/50"
+                        }
+                      >
+                        <td className="px-4 py-2.5 font-medium text-slate-700 dark:text-slate-300">
+                          {label}
+                          {isCurrent && (
+                            <span className="ml-2 text-xs text-green-600 dark:text-green-400">active</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2.5 text-right text-slate-600 dark:text-slate-400">
+                          {m.num_pdf_chunks.toLocaleString()}
+                        </td>
+                        <td className="px-4 py-2.5 text-right text-slate-600 dark:text-slate-400">
+                          {m.num_documents.toLocaleString()}
+                        </td>
+                        <td className="px-4 py-2.5 text-center">{fmtPct(m.source_hit_rate)}</td>
+                        <td className={`px-4 py-2.5 text-center font-medium ${
+                          isBestKw ? "text-green-600 dark:text-green-400" : ""
+                        }`}>
+                          {fmtPct(m.keyword_hit_rate)}
+                        </td>
+                        <td className="px-4 py-2.5 text-center">{fmtMrr(m.mrr)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Bar chart for keyword hit rate */}
+            <BarComparison
+              data={Object.entries(chunkResults).map(([name, m]) => ({
+                name,
+                keywordHit: m.keyword_hit_rate * 100,
+              }))}
+              metricKey="keywordHit"
+              label="Keyword Hit Rate by Chunk Size (%)"
+              formatFn={(v) => `${v.toFixed(0)}%`}
+            />
+          </div>
+        )}
+      </section>
+
+      {/* Section 3: Test Suite */}
+      {testSuite && (
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+            Benchmark Test Suite ({testSuite.length} Questions)
+          </h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Mix of easy keyword matches, paraphrased queries, vague questions, and adversarial inputs
+            designed to differentiate search methods.
+          </p>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-slate-700">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-slate-50 text-xs uppercase text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+                <tr>
+                  <th className="px-4 py-3 w-8">#</th>
+                  <th className="px-4 py-3">Question</th>
+                  <th className="px-4 py-3">Expected Source</th>
+                  <th className="px-4 py-3">Expected Keywords</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
+                {testSuite.map((t, i) => (
+                  <tr key={i} className="hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                    <td className="px-4 py-2.5 text-slate-400">{i + 1}</td>
+                    <td className="px-4 py-2.5 text-slate-700 dark:text-slate-300">{t.question}</td>
+                    <td className="px-4 py-2.5">
+                      <span className="rounded bg-slate-100 px-2 py-0.5 text-xs font-mono text-slate-600 dark:bg-slate-700 dark:text-slate-400">
+                        {t.expected_source}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-slate-500 dark:text-slate-400">
+                      {t.expected_keywords.join(", ")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -1,8 +1,8 @@
-export async function sendMessage(question) {
+export async function sendMessage(question, history = []) {
   const res = await fetch("/api/chat", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ question }),
+    body: JSON.stringify({ question, history }),
   });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -51,3 +51,21 @@ export async function fetchBuffettAnalysis(symbol) {
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
 }
+
+export async function fetchSearchMethodEval() {
+  const res = await fetch("/api/evaluation/search-methods");
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchChunkSizeEval() {
+  const res = await fetch("/api/evaluation/chunk-sizes");
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchTestSuite() {
+  const res = await fetch("/api/evaluation/test-suite");
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}


### PR DESCRIPTION
  1. RAG Evaluation Dashboard -- Measures RAG quality. Runs a test suite of questions and scores retrieval relevance + answer faithfulness.
 
  2. Hybrid Search (BM25 + FAISS) --  Adding keyword search (BM25) and combining results catches cases
  where semantic search misses exact terms. This is a well-known RAG improvement technique and shows depth of understanding.
 
  3. Reranking with a Cross-Encoder -- After FAISS retrieves top-k chunks, run them through a cross-encoder model to rerank by relevance. This is a standard production RAG pattern and would show you know the difference between bi-encoder retrieval and cross-encoder reranking.
 
  4. Conversation Memory -- Right now each question is independent. Adding context from the previous turn so users can ask follow-ups like
  "Tell me more about that" or "What about his view on debt?" would demonstrate understanding of context window management.
 