### PR TITLE
Fix chat app navbar and Python 3.9 compatibility

### DIFF
--- a/server.py
+++ b/server.py
@@ -6,6 +6,7 @@ Run with:  uvicorn server:app --reload --port 8000
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from typing import Optional
 from pydantic import BaseModel
 
 app = FastAPI(title="Buffett RAG API")
@@ -281,7 +282,7 @@ class BacktestRequest(BaseModel):
     symbol: str
     strategy: str
     startDate: str = "2018-01-01"
-    endDate: str | None = None
+    endDate: Optional[str] = None
     shortWindow: int = 20
     longWindow: int = 50
     rsiPeriod: int = 14

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -15,15 +15,22 @@ export default function App() {
     <ThemeProvider>
       {loading && <SplashScreen onComplete={() => setLoading(false)} />}
       <BrowserRouter>
-        <PageLayout>
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/chat" element={<ChatPage />} />
-            <Route path="/trading" element={<TradingPage />} />
-            <Route path="/evaluation" element={<EvaluationPage />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
-        </PageLayout>
+        <Routes>
+          <Route path="/chat" element={<ChatPage />} />
+          <Route
+            path="/*"
+            element={
+              <PageLayout>
+                <Routes>
+                  <Route path="/" element={<HomePage />} />
+                  <Route path="/trading" element={<TradingPage />} />
+                  <Route path="/evaluation" element={<EvaluationPage />} />
+                  <Route path="*" element={<Navigate to="/" replace />} />
+                </Routes>
+              </PageLayout>
+            }
+          />
+        </Routes>
       </BrowserRouter>
     </ThemeProvider>
   );

--- a/ui/src/pages/ChatPage.jsx
+++ b/ui/src/pages/ChatPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { BarChart3, TrendingUp, Sun, Moon } from 'lucide-react';
+import { BarChart3, TrendingUp, FlaskConical, Sun, Moon } from 'lucide-react';
 import warrenAvatar from '../assets/warren-avatar-sm.png';
 import warrenLogo from '../assets/warren-logo.png';
 import ChatMessage from '../components/chat/ChatMessage';
@@ -200,15 +200,21 @@ export default function ChatPage() {
           <div className='flex items-center gap-1'>
             <Link
               to='/'
-              className='flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200'
+              className='flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200'
             >
-              <BarChart3 size={14} /> Portfolio
+              <BarChart3 size={16} /> <span className='hidden sm:inline'>Portfolio</span>
             </Link>
             <Link
               to='/trading'
-              className='flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200'
+              className='flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200'
             >
-              <TrendingUp size={14} /> Trading
+              <TrendingUp size={16} /> <span className='hidden sm:inline'>Trading</span>
+            </Link>
+            <Link
+              to='/evaluation'
+              className='flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200'
+            >
+              <FlaskConical size={16} /> <span className='hidden sm:inline'>Evaluation</span>
             </Link>
             <button
               onClick={toggle}


### PR DESCRIPTION
## Summary
- **Chat page layout fix**: Moved `/chat` route outside `PageLayout` so the global navbar no longer overlaps with ChatPage's own fixed layout, fixing content clipping
- **Chat navbar parity**: Added Evaluation link and normalized font sizes (`text-sm font-medium`) to match the global navbar
- **Python 3.9 fix**: Replaced `str | None` with `Optional[str]` in `server.py` for compatibility with Python 3.9

## Test plan
- [x] Navigate to `/chat` — sidebar and content should render correctly without clipping
- [x] Verify Evaluation link appears in the chat navbar and navigates to `/evaluation`
- [x] Verify navbar styling is consistent between chat page and other pages
- [ ] Run `uvicorn server:app --port 8000` on Python 3.9 — should start without TypeError