### PR TITLE
Feature: Chat slash commands with Trading page integration

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -59,6 +59,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -266,27 +267,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1262,6 +1242,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1314,6 +1295,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1422,6 +1404,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1782,6 +1765,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2770,6 +2754,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2830,6 +2815,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2839,6 +2825,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2858,6 +2845,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -2948,7 +2936,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -3232,6 +3221,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3356,6 +3346,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/src/components/buffett/TradelikBuffett.jsx
+++ b/ui/src/components/buffett/TradelikBuffett.jsx
@@ -1,6 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Plus, Trash2, BarChart3, Loader2, Quote, Shield, Pencil, Check, X } from "lucide-react";
 import { fetchBuffettAnalysis } from "../../services/api";
+import { scoreHex, getScoreStyle } from "../../utils/buffettScoring";
+import DonutChart from "../shared/DonutChart";
 
 const SUGGESTED_STOCKS = [
   { symbol: "AAPL", name: "Apple" },
@@ -14,37 +16,6 @@ const SUGGESTED_STOCKS = [
   { symbol: "TSLA", name: "Tesla" },
   { symbol: "AMZN", name: "Amazon" },
 ];
-
-const SCORE_HEX = { strong: "#10b981", mixed: "#f59e0b", weak: "#ef4444", none: "#94a3b8" };
-
-function scoreHex(passRate) {
-  if (passRate >= 0.7) return SCORE_HEX.strong;
-  if (passRate >= 0.4) return SCORE_HEX.mixed;
-  return SCORE_HEX.weak;
-}
-
-function getScoreStyle(passRate) {
-  if (passRate >= 0.7)
-    return {
-      bg: "bg-emerald-50 dark:bg-emerald-500/10",
-      text: "text-emerald-700 dark:text-emerald-400",
-      badge: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400",
-      label: "Strong",
-    };
-  if (passRate >= 0.4)
-    return {
-      bg: "bg-amber-50 dark:bg-amber-500/10",
-      text: "text-amber-700 dark:text-amber-400",
-      badge: "bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400",
-      label: "Mixed",
-    };
-  return {
-    bg: "bg-red-50 dark:bg-red-500/10",
-    text: "text-red-700 dark:text-red-400",
-    badge: "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400",
-    label: "Weak",
-  };
-}
 
 const moatColor = {
   Wide: "text-emerald-600 dark:text-emerald-400",
@@ -67,48 +38,6 @@ const criteriaColor = {
   fail: "bg-red-500",
 };
 
-// ── Donut chart ──────────────────────────────────────────────────────────────
-function DonutChart({ segments, centerLabel, centerSub }) {
-  const r = 58;
-  const cx = 72;
-  const cy = 72;
-  const circumference = 2 * Math.PI * r;
-  const total = segments.reduce((s, seg) => s + seg.value, 0) || 1;
-  const gap = segments.length > 1 ? circumference * (1.8 / 360) : 0;
-
-  let accumulated = 0;
-  return (
-    <svg width="144" height="144" viewBox="0 0 144 144" className="overflow-visible">
-      {/* track */}
-      <circle cx={cx} cy={cy} r={r} fill="none" stroke="#e2e8f0" strokeWidth="22"
-        className="dark:[stroke:#1e293b]" />
-      {segments.map((seg, i) => {
-        const dash = Math.max(0, (seg.value / total) * circumference - gap);
-        const rotate = (accumulated / total) * 360 - 90;
-        accumulated += seg.value;
-        return (
-          <circle
-            key={i}
-            cx={cx} cy={cy} r={r}
-            fill="none"
-            stroke={seg.color}
-            strokeWidth="22"
-            strokeLinecap="butt"
-            strokeDasharray={`${dash} ${circumference - dash}`}
-            transform={`rotate(${rotate}, ${cx}, ${cy})`}
-            style={{ filter: "drop-shadow(0 1px 3px rgba(0,0,0,.15))" }}
-          />
-        );
-      })}
-      {/* center label */}
-      <text x={cx} y={cy - 7} textAnchor="middle" fill="currentColor"
-        fontSize="20" fontWeight="700">{centerLabel}</text>
-      <text x={cx} y={cx + 11} textAnchor="middle" fill="#94a3b8"
-        fontSize="9" fontWeight="500" letterSpacing="0.08em">{centerSub}</text>
-    </svg>
-  );
-}
-
 // ── Score card ────────────────────────────────────────────────────────────────
 function ScoreCard({ label, value, colorClass = "text-slate-900 dark:text-slate-100", sub }) {
   return (
@@ -121,18 +50,23 @@ function ScoreCard({ label, value, colorClass = "text-slate-900 dark:text-slate-
 }
 
 // ── Main component ────────────────────────────────────────────────────────────
-export default function TradeLikeBuffett() {
+export default function TradeLikeBuffett({ initialHoldings = null }) {
   const [tickerInput, setTickerInput] = useState("");
   const [weightInput, setWeightInput] = useState("");
-  const [holdings, setHoldings] = useState([
-    { symbol: "AAPL", weight: 42 },
-    { symbol: "BAC", weight: 13 },
-    { symbol: "AXP", weight: 10 },
-    { symbol: "KO", weight: 9 },
-    { symbol: "CVX", weight: 14 },
-    { symbol: "OXY", weight: 12 },
-  ]);
+  const [holdings, setHoldings] = useState(
+    initialHoldings && initialHoldings.length > 0
+      ? initialHoldings
+      : [
+          { symbol: "AAPL", weight: 42 },
+          { symbol: "BAC", weight: 13 },
+          { symbol: "AXP", weight: 10 },
+          { symbol: "KO", weight: 9 },
+          { symbol: "CVX", weight: 14 },
+          { symbol: "OXY", weight: 12 },
+        ]
+  );
   const [analyzed, setAnalyzed] = useState(false);
+  const autoAnalyzed = useRef(false);
   const [editingSymbol, setEditingSymbol] = useState(null);
   const [editWeight, setEditWeight] = useState("");
   const [tooltip, setTooltip] = useState(null); // { x, y, item }
@@ -143,6 +77,14 @@ export default function TradeLikeBuffett() {
   const [error, setError] = useState(null);
 
   const totalWeight = holdings.reduce((sum, h) => sum + h.weight, 0);
+
+  // Auto-analyze when navigating from chat with initialHoldings
+  useEffect(() => {
+    if (initialHoldings && initialHoldings.length > 0 && !autoAnalyzed.current) {
+      autoAnalyzed.current = true;
+      analyzePortfolio();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   function addHolding() {
     const sym = tickerInput.trim().toUpperCase();

--- a/ui/src/components/chat/ChatInput.jsx
+++ b/ui/src/components/chat/ChatInput.jsx
@@ -1,38 +1,247 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Send } from "lucide-react";
+import SlashCommandMenu from "./SlashCommandMenu";
+import StockAutocomplete from "./StockAutocomplete";
+import PortfolioBuilder from "./PortfolioBuilder";
+import { SLASH_COMMANDS, STOCK_LIST } from "../../data/slashCommands";
 
-export default function ChatInput({ onSend, disabled }) {
+const OPINION_TEMPLATE = "What would Buffett think of ";
+
+export default function ChatInput({ onSend, onSendPortfolio, disabled }) {
   const [text, setText] = useState("");
+  const [showSlashMenu, setShowSlashMenu] = useState(false);
+  const [slashFilter, setSlashFilter] = useState("");
+  const [selectedSlashIdx, setSelectedSlashIdx] = useState(0);
+  const [activeCommand, setActiveCommand] = useState(null);
+  const [showStockAutocomplete, setShowStockAutocomplete] = useState(false);
+  const [selectedStockIdx, setSelectedStockIdx] = useState(0);
+  const inputRef = useRef(null);
+  const wrapperRef = useRef(null);
+
+  // Filter commands based on what user typed after "/"
+  const filteredCommands = SLASH_COMMANDS.filter((cmd) =>
+    cmd.label.toLowerCase().includes(slashFilter.toLowerCase())
+  );
+
+  // Filter stocks based on what user typed after the template
+  const stockFilter =
+    activeCommand === "buffett-opinion" && text.startsWith(OPINION_TEMPLATE)
+      ? text.slice(OPINION_TEMPLATE.length).replace(/\?$/, "").trim()
+      : "";
+
+  const filteredStocks =
+    stockFilter.length > 0
+      ? STOCK_LIST.filter(
+          (s) =>
+            s.symbol.toLowerCase().includes(stockFilter.toLowerCase()) ||
+            s.name.toLowerCase().includes(stockFilter.toLowerCase())
+        ).slice(0, 8)
+      : [];
+
+  // Close menus on click outside
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+        setShowSlashMenu(false);
+        setShowStockAutocomplete(false);
+      }
+    }
+    if (showSlashMenu || showStockAutocomplete) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [showSlashMenu, showStockAutocomplete]);
+
+  // Show/hide stock autocomplete based on filter
+  useEffect(() => {
+    if (activeCommand === "buffett-opinion" && filteredStocks.length > 0 && stockFilter.length > 0) {
+      setShowStockAutocomplete(true);
+      setSelectedStockIdx(0);
+    } else {
+      setShowStockAutocomplete(false);
+    }
+  }, [stockFilter, activeCommand, filteredStocks.length]);
+
+  function handleChange(e) {
+    const val = e.target.value;
+    setText(val);
+
+    // Detect "/" at start of input (only when not in a command mode)
+    if (!activeCommand) {
+      if (val.startsWith("/")) {
+        setShowSlashMenu(true);
+        setSlashFilter(val.slice(1));
+        setSelectedSlashIdx(0);
+      } else {
+        setShowSlashMenu(false);
+        setSlashFilter("");
+      }
+    }
+  }
+
+  function handleSelectCommand(cmd) {
+    setShowSlashMenu(false);
+    setSlashFilter("");
+
+    if (cmd.id === "buffett-opinion") {
+      setActiveCommand("buffett-opinion");
+      setText(OPINION_TEMPLATE);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    } else if (cmd.id === "trade-like-buffett") {
+      setActiveCommand("trade-like-buffett");
+      setText("");
+    }
+  }
+
+  function handleSelectStock(stock) {
+    setShowStockAutocomplete(false);
+    setText(`What would Buffett think of ${stock.symbol}?`);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }
+
+  function handleCancelPortfolio() {
+    setActiveCommand(null);
+    setText("");
+  }
+
+  function handleAnalyzePortfolio(holdings) {
+    setActiveCommand(null);
+    setText("");
+    onSendPortfolio(holdings);
+  }
+
+  function handleKeyDown(e) {
+    // Slash menu navigation
+    if (showSlashMenu && filteredCommands.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedSlashIdx((prev) =>
+          prev < filteredCommands.length - 1 ? prev + 1 : 0
+        );
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedSlashIdx((prev) =>
+          prev > 0 ? prev - 1 : filteredCommands.length - 1
+        );
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        if (filteredCommands[selectedSlashIdx]) {
+          handleSelectCommand(filteredCommands[selectedSlashIdx]);
+        }
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setShowSlashMenu(false);
+        setText("");
+        return;
+      }
+    }
+
+    // Stock autocomplete navigation
+    if (showStockAutocomplete && filteredStocks.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedStockIdx((prev) =>
+          prev < filteredStocks.length - 1 ? prev + 1 : 0
+        );
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedStockIdx((prev) =>
+          prev > 0 ? prev - 1 : filteredStocks.length - 1
+        );
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleSelectStock(filteredStocks[selectedStockIdx]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setShowStockAutocomplete(false);
+        return;
+      }
+    }
+
+    // Escape out of command mode
+    if (e.key === "Escape" && activeCommand) {
+      e.preventDefault();
+      setActiveCommand(null);
+      setText("");
+    }
+  }
 
   function handleSubmit(e) {
     e.preventDefault();
+    if (showSlashMenu || showStockAutocomplete) return;
     const trimmed = text.trim();
     if (!trimmed || disabled) return;
     onSend(trimmed);
     setText("");
+    setActiveCommand(null);
+  }
+
+  // Portfolio builder mode — replace entire input area
+  if (activeCommand === "trade-like-buffett") {
+    return (
+      <PortfolioBuilder
+        onAnalyze={handleAnalyzePortfolio}
+        onCancel={handleCancelPortfolio}
+        disabled={disabled}
+      />
+    );
   }
 
   return (
     <div className="border-t border-slate-200 bg-white px-4 pt-4 pb-3 dark:border-slate-800 dark:bg-[#0d1520]">
-      <form onSubmit={handleSubmit}>
-        <div className="mx-auto flex max-w-3xl items-center gap-3">
-          <input
-            type="text"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            placeholder="Send a message."
-            disabled={disabled}
-            className="flex-1 rounded-xl border border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-900 placeholder-slate-400 outline-none transition-colors focus:border-red-500/50 focus:ring-1 focus:ring-red-500/20 disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder-slate-500"
+      <div ref={wrapperRef} className="relative">
+        {/* Slash command menu */}
+        {showSlashMenu && filteredCommands.length > 0 && (
+          <SlashCommandMenu
+            commands={filteredCommands}
+            selectedIdx={selectedSlashIdx}
+            onSelect={handleSelectCommand}
           />
-          <button
-            type="submit"
-            disabled={disabled || !text.trim()}
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-red-500 text-slate-950 transition-all hover:bg-red-400 disabled:opacity-30 disabled:hover:bg-red-500"
-          >
-            <Send size={16} />
-          </button>
-        </div>
-      </form>
+        )}
+
+        {/* Stock autocomplete */}
+        {showStockAutocomplete && filteredStocks.length > 0 && (
+          <StockAutocomplete
+            stocks={filteredStocks}
+            selectedIdx={selectedStockIdx}
+            onSelect={handleSelectStock}
+          />
+        )}
+
+        <form onSubmit={handleSubmit}>
+          <div className="mx-auto flex max-w-3xl items-center gap-3">
+            <input
+              ref={inputRef}
+              type="text"
+              value={text}
+              onChange={handleChange}
+              onKeyDown={handleKeyDown}
+              placeholder='Type / for commands, or send a message.'
+              disabled={disabled}
+              className="flex-1 rounded-xl border border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-900 placeholder-slate-400 outline-none transition-colors focus:border-red-500/50 focus:ring-1 focus:ring-red-500/20 disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder-slate-500"
+            />
+            <button
+              type="submit"
+              disabled={disabled || !text.trim()}
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-red-500 text-slate-950 transition-all hover:bg-red-400 disabled:opacity-30 disabled:hover:bg-red-500"
+            >
+              <Send size={16} />
+            </button>
+          </div>
+        </form>
+      </div>
       <p className="mx-auto mt-2.5 max-w-3xl text-center text-xs leading-relaxed text-slate-400 dark:text-slate-500">
         Ask Warren AI can make mistakes. Check important info.
         <br />

--- a/ui/src/components/chat/ChatMessage.jsx
+++ b/ui/src/components/chat/ChatMessage.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from "react";
-import { User } from "lucide-react";
+import { User, ArrowRight } from "lucide-react";
+import { Link } from "react-router-dom";
 import SourceCard from "./SourceCard";
 import StockCard from "./StockCard";
+import PortfolioOverviewCard from "./PortfolioOverviewCard";
 import warrenAvatar from "../../assets/warren-avatar-sm.png";
 
 function useTypingEffect(text, enabled) {
@@ -61,6 +63,11 @@ export default function ChatMessage({ message, animate = false }) {
 
       {/* Content */}
       <div className={`max-w-[80%] space-y-2 ${isUser ? "text-right" : ""}`}>
+        {/* Portfolio overview card — for portfolio analysis responses */}
+        {!isUser && message.type === "portfolio-overview" && message.portfolio_data && (
+          <PortfolioOverviewCard data={message.portfolio_data} />
+        )}
+
         {/* Stock data card — shown above text for stock queries */}
         {!isUser && message.stock_data && (
           <StockCard data={message.stock_data} />
@@ -78,6 +85,16 @@ export default function ChatMessage({ message, animate = false }) {
             <span className="ml-0.5 inline-block h-4 w-0.5 animate-pulse bg-slate-1000 dark:bg-red-400" />
           )}
         </div>
+
+        {/* View Detailed Analysis link — for Buffett opinion responses */}
+        {done && message.buffett_analysis && (
+          <Link
+            to={`/trading?tab=trading&symbol=${message.buffett_analysis.stock_data?.ticker || ""}`}
+            className="inline-flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-100 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-400 dark:hover:bg-red-500/20"
+          >
+            View Detailed Analysis <ArrowRight size={14} />
+          </Link>
+        )}
 
         {/* Sources — show after typing finishes */}
         {done && message.sources?.length > 0 && (

--- a/ui/src/components/chat/PortfolioBuilder.jsx
+++ b/ui/src/components/chat/PortfolioBuilder.jsx
@@ -1,0 +1,235 @@
+import { useState, useRef, useEffect } from "react";
+import { Plus, X, BarChart3 } from "lucide-react";
+import StockAutocomplete from "./StockAutocomplete";
+import { STOCK_LIST } from "../../data/slashCommands";
+
+const SUGGESTED = ["AAPL", "KO", "BAC", "MSFT", "NVDA", "JPM", "TSLA", "AMZN"];
+
+export default function PortfolioBuilder({ onAnalyze, onCancel, disabled }) {
+  const [tickerInput, setTickerInput] = useState("");
+  const [weightInput, setWeightInput] = useState("");
+  const [holdings, setHoldings] = useState([]);
+  const [error, setError] = useState(null);
+  const [showAutocomplete, setShowAutocomplete] = useState(false);
+  const [selectedStockIdx, setSelectedStockIdx] = useState(0);
+  const tickerRef = useRef(null);
+  const wrapperRef = useRef(null);
+
+  const totalWeight = holdings.reduce((s, h) => s + h.weight, 0);
+
+  const filteredStocks =
+    tickerInput.length > 0
+      ? STOCK_LIST.filter(
+          (s) =>
+            s.symbol.toLowerCase().includes(tickerInput.toLowerCase()) ||
+            s.name.toLowerCase().includes(tickerInput.toLowerCase())
+        ).slice(0, 6)
+      : [];
+
+  useEffect(() => {
+    if (filteredStocks.length > 0 && tickerInput.length > 0) {
+      setShowAutocomplete(true);
+      setSelectedStockIdx(0);
+    } else {
+      setShowAutocomplete(false);
+    }
+  }, [tickerInput, filteredStocks.length]);
+
+  // Close autocomplete on click outside
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+        setShowAutocomplete(false);
+      }
+    }
+    if (showAutocomplete) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [showAutocomplete]);
+
+  function addHolding() {
+    const sym = tickerInput.trim().toUpperCase();
+    const wt = parseFloat(weightInput);
+    if (!sym || isNaN(wt) || wt <= 0) return;
+    if (holdings.some((h) => h.symbol === sym)) {
+      setError(`${sym} is already added.`);
+      return;
+    }
+    setError(null);
+    setHoldings((prev) => [...prev, { symbol: sym, weight: wt }]);
+    setTickerInput("");
+    setWeightInput("");
+    tickerRef.current?.focus();
+  }
+
+  function removeHolding(symbol) {
+    setHoldings((prev) => prev.filter((h) => h.symbol !== symbol));
+  }
+
+  function handleSelectStock(stock) {
+    setTickerInput(stock.symbol);
+    setShowAutocomplete(false);
+    // Focus weight input after selecting ticker
+    setTimeout(() => {
+      const weightEl = document.getElementById("portfolio-weight-input");
+      weightEl?.focus();
+    }, 0);
+  }
+
+  function handleTickerKeyDown(e) {
+    if (showAutocomplete && filteredStocks.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedStockIdx((p) => (p < filteredStocks.length - 1 ? p + 1 : 0));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedStockIdx((p) => (p > 0 ? p - 1 : filteredStocks.length - 1));
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleSelectStock(filteredStocks[selectedStockIdx]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setShowAutocomplete(false);
+        return;
+      }
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addHolding();
+    }
+  }
+
+  function handleSubmit() {
+    if (holdings.length === 0 || disabled) return;
+    onAnalyze(holdings);
+  }
+
+  return (
+    <div className="border-t border-slate-200 bg-white px-4 pt-4 pb-3 dark:border-slate-800 dark:bg-[#0d1520]">
+      <div className="mx-auto max-w-3xl">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <BarChart3 size={16} className="text-red-500" />
+            <span className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+              Trade like Buffett
+            </span>
+          </div>
+          <button
+            onClick={onCancel}
+            className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-300"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Input row */}
+        <div ref={wrapperRef} className="relative">
+          {showAutocomplete && filteredStocks.length > 0 && (
+            <StockAutocomplete
+              stocks={filteredStocks}
+              selectedIdx={selectedStockIdx}
+              onSelect={handleSelectStock}
+            />
+          )}
+          <div className="flex flex-wrap gap-2">
+            <input
+              ref={tickerRef}
+              type="text"
+              value={tickerInput}
+              onChange={(e) => setTickerInput(e.target.value.toUpperCase())}
+              onKeyDown={handleTickerKeyDown}
+              placeholder="Ticker (e.g. AAPL)"
+              disabled={disabled}
+              className="w-36 rounded-lg border border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-900 outline-none focus:border-red-500/50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 placeholder:text-slate-400 disabled:opacity-50"
+            />
+            <input
+              id="portfolio-weight-input"
+              type="number"
+              value={weightInput}
+              onChange={(e) => setWeightInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), addHolding())}
+              placeholder="Weight %"
+              min="0.1"
+              max="100"
+              disabled={disabled}
+              className="w-24 rounded-lg border border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-900 outline-none focus:border-red-500/50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 placeholder:text-slate-400 disabled:opacity-50"
+            />
+            <button
+              onClick={addHolding}
+              disabled={!tickerInput.trim() || !weightInput || disabled}
+              className="flex items-center gap-1 rounded-lg bg-slate-900 px-3 py-2 text-sm font-medium text-white transition hover:bg-slate-700 disabled:opacity-40 dark:bg-slate-700 dark:hover:bg-slate-600"
+            >
+              <Plus size={14} /> Add
+            </button>
+          </div>
+        </div>
+
+        {/* Suggested stocks */}
+        <div className="mt-2 flex flex-wrap gap-1">
+          {SUGGESTED.map((sym) => (
+            <button
+              key={sym}
+              onClick={() => setTickerInput(sym)}
+              disabled={disabled}
+              className="rounded-full border border-slate-200 px-2 py-0.5 text-[10px] text-slate-500 transition-colors hover:border-red-300 hover:text-red-600 dark:border-slate-700 dark:text-slate-400 dark:hover:border-red-500/30 dark:hover:text-red-400 disabled:opacity-50"
+            >
+              {sym}
+            </button>
+          ))}
+        </div>
+
+        {error && (
+          <p className="mt-2 text-xs text-red-500">{error}</p>
+        )}
+
+        {/* Holdings chips */}
+        {holdings.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {holdings.map((h) => (
+              <div
+                key={h.symbol}
+                className="flex items-center gap-1.5 rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-sm dark:border-slate-700 dark:bg-slate-800"
+              >
+                <span className="font-semibold text-slate-800 dark:text-slate-200">
+                  {h.symbol}
+                </span>
+                <span className="text-xs text-slate-400">{h.weight}%</span>
+                <button
+                  onClick={() => removeHolding(h.symbol)}
+                  disabled={disabled}
+                  className="ml-0.5 flex h-4 w-4 items-center justify-center rounded text-slate-400 transition-colors hover:bg-red-100 hover:text-red-500 dark:hover:bg-red-500/20 dark:hover:text-red-400"
+                >
+                  <X size={10} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Footer: total weight + analyze button */}
+        <div className="mt-3 flex items-center justify-between">
+          <span className="text-xs text-slate-400">
+            {holdings.length > 0
+              ? `${holdings.length} stock${holdings.length > 1 ? "s" : ""} · Total: ${totalWeight}%`
+              : "Add stocks to build your portfolio"}
+          </span>
+          <button
+            onClick={handleSubmit}
+            disabled={holdings.length === 0 || disabled}
+            className="flex items-center gap-2 rounded-lg bg-red-500 px-4 py-2 text-sm font-medium text-white transition-all hover:bg-red-400 disabled:opacity-40 disabled:hover:bg-red-500"
+          >
+            <BarChart3 size={14} /> Analyze Portfolio
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/chat/PortfolioOverviewCard.jsx
+++ b/ui/src/components/chat/PortfolioOverviewCard.jsx
@@ -1,0 +1,94 @@
+import { ArrowRight } from "lucide-react";
+import { Link } from "react-router-dom";
+import DonutChart from "../shared/DonutChart";
+
+function ScoreCard({ label, value, colorClass = "text-slate-900 dark:text-slate-100", sub }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900/60">
+      <p className="text-[10px] font-medium uppercase tracking-wider text-slate-400 whitespace-nowrap">{label}</p>
+      <p className={`mt-1 text-2xl font-bold ${colorClass}`}>{value}</p>
+      {sub && <p className="mt-0.5 text-[11px] text-slate-400">{sub}</p>}
+    </div>
+  );
+}
+
+function scoreColor(score) {
+  const n = parseFloat(score);
+  if (n >= 7) return "text-emerald-600 dark:text-emerald-400";
+  if (n >= 4) return "text-amber-600 dark:text-amber-400";
+  return "text-red-600 dark:text-red-400";
+}
+
+export default function PortfolioOverviewCard({ data }) {
+  const { holdings, results, avgScore, weightedScore, strongPicks, donutSegments } = data;
+  const stockCount = results?.length || 0;
+
+  // Encode holdings for deep link: AAPL:42,BAC:13,KO:9
+  const holdingsParam = (holdings || [])
+    .map((h) => `${h.symbol}:${h.weight}`)
+    .join(",");
+
+  return (
+    <div className="w-full rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/80" style={{ maxWidth: "560px" }}>
+      <p className="mb-5 text-xs font-semibold uppercase tracking-wider text-slate-400">
+        Portfolio Analysis
+      </p>
+
+      <div className="flex flex-col sm:flex-row gap-6">
+        {/* Donut + Legend */}
+        <div className="flex flex-col items-center shrink-0">
+          <DonutChart
+            segments={donutSegments}
+            centerLabel={weightedScore}
+            centerSub="WEIGHTED"
+          />
+          <div className="mt-3 flex flex-wrap justify-center gap-x-3 gap-y-1.5">
+            {donutSegments.map((seg) => (
+              <div key={seg.symbol} className="flex items-center gap-1.5">
+                <span
+                  className="inline-block h-2.5 w-2.5 rounded-full"
+                  style={{ backgroundColor: seg.color }}
+                />
+                <span className="text-[11px] font-medium text-slate-500 dark:text-slate-400">
+                  {seg.symbol}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Score cards 2×2 */}
+        <div className="grid flex-1 grid-cols-2 gap-3 content-start">
+          <ScoreCard label="Stocks Analyzed" value={stockCount} />
+          <ScoreCard
+            label="Avg Buffett Score"
+            value={`${avgScore}/10`}
+            colorClass={scoreColor(avgScore)}
+            sub="unweighted average"
+          />
+          <ScoreCard
+            label="Weighted Score"
+            value={`${weightedScore}/10`}
+            colorClass={scoreColor(weightedScore)}
+            sub="by allocation weight"
+          />
+          <ScoreCard
+            label="Strong Picks"
+            value={`${strongPicks}/${stockCount}`}
+            sub={"\u2265 70% criteria passing"}
+          />
+        </div>
+      </div>
+
+      {/* See Detailed Analysis button */}
+      <div className="mt-5 flex justify-end">
+        <Link
+          to={`/trading?tab=buffett&holdings=${encodeURIComponent(holdingsParam)}`}
+          className="inline-flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-100 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-400 dark:hover:bg-red-500/20"
+        >
+          See Detailed Analysis <ArrowRight size={14} />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/chat/SlashCommandMenu.jsx
+++ b/ui/src/components/chat/SlashCommandMenu.jsx
@@ -1,0 +1,55 @@
+import { MessageSquareText, Briefcase } from "lucide-react";
+
+const ICONS = {
+  "buffett-opinion": MessageSquareText,
+  "trade-like-buffett": Briefcase,
+};
+
+export default function SlashCommandMenu({ commands, selectedIdx, onSelect }) {
+  return (
+    <div className="absolute bottom-full left-0 right-0 mb-2 mx-auto max-w-3xl">
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-900">
+        <div className="px-3 py-2 border-b border-slate-100 dark:border-slate-800">
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+            Commands
+          </p>
+        </div>
+        {commands.map((cmd, i) => {
+          const Icon = ICONS[cmd.id] || MessageSquareText;
+          return (
+            <button
+              key={cmd.id}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSelect(cmd);
+              }}
+              className={`flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors ${
+                i === selectedIdx
+                  ? "bg-red-50 dark:bg-red-500/10"
+                  : "hover:bg-slate-50 dark:hover:bg-slate-800/60"
+              }`}
+            >
+              <div
+                className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${
+                  i === selectedIdx
+                    ? "bg-red-100 text-red-600 dark:bg-red-500/20 dark:text-red-400"
+                    : "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400"
+                }`}
+              >
+                <Icon size={16} />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-slate-800 dark:text-slate-200">
+                  /{cmd.label}
+                </p>
+                <p className="text-xs text-slate-400 dark:text-slate-500">
+                  {cmd.description}
+                </p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/chat/StockAutocomplete.jsx
+++ b/ui/src/components/chat/StockAutocomplete.jsx
@@ -1,0 +1,51 @@
+import { TrendingUp } from "lucide-react";
+
+export default function StockAutocomplete({ stocks, selectedIdx, onSelect }) {
+  if (stocks.length === 0) return null;
+
+  return (
+    <div className="absolute bottom-full left-0 right-0 mb-2 mx-auto max-w-3xl">
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-900">
+        <div className="px-3 py-2 border-b border-slate-100 dark:border-slate-800">
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+            Select a stock
+          </p>
+        </div>
+        <div className="max-h-56 overflow-y-auto">
+          {stocks.map((stock, i) => (
+            <button
+              key={stock.symbol}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSelect(stock);
+              }}
+              className={`flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors ${
+                i === selectedIdx
+                  ? "bg-red-50 dark:bg-red-500/10"
+                  : "hover:bg-slate-50 dark:hover:bg-slate-800/60"
+              }`}
+            >
+              <div
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-xs font-bold ${
+                  i === selectedIdx
+                    ? "bg-red-100 text-red-600 dark:bg-red-500/20 dark:text-red-400"
+                    : "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400"
+                }`}
+              >
+                <TrendingUp size={14} />
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+                  {stock.symbol}
+                </span>
+                <span className="text-xs text-slate-400 dark:text-slate-500">
+                  {stock.name}
+                </span>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/shared/DonutChart.jsx
+++ b/ui/src/components/shared/DonutChart.jsx
@@ -1,0 +1,40 @@
+export default function DonutChart({ segments, centerLabel, centerSub }) {
+  const r = 58;
+  const cx = 72;
+  const cy = 72;
+  const circumference = 2 * Math.PI * r;
+  const total = segments.reduce((s, seg) => s + seg.value, 0) || 1;
+  const gap = segments.length > 1 ? circumference * (1.8 / 360) : 0;
+
+  let accumulated = 0;
+  return (
+    <svg width="144" height="144" viewBox="0 0 144 144" className="overflow-visible">
+      {/* track */}
+      <circle cx={cx} cy={cy} r={r} fill="none" stroke="#e2e8f0" strokeWidth="22"
+        className="dark:[stroke:#1e293b]" />
+      {segments.map((seg, i) => {
+        const dash = Math.max(0, (seg.value / total) * circumference - gap);
+        const rotate = (accumulated / total) * 360 - 90;
+        accumulated += seg.value;
+        return (
+          <circle
+            key={i}
+            cx={cx} cy={cy} r={r}
+            fill="none"
+            stroke={seg.color}
+            strokeWidth="22"
+            strokeLinecap="butt"
+            strokeDasharray={`${dash} ${circumference - dash}`}
+            transform={`rotate(${rotate}, ${cx}, ${cy})`}
+            style={{ filter: "drop-shadow(0 1px 3px rgba(0,0,0,.15))" }}
+          />
+        );
+      })}
+      {/* center label */}
+      <text x={cx} y={cy - 7} textAnchor="middle" fill="currentColor"
+        fontSize="20" fontWeight="700">{centerLabel}</text>
+      <text x={cx} y={cx + 11} textAnchor="middle" fill="#94a3b8"
+        fontSize="9" fontWeight="500" letterSpacing="0.08em">{centerSub}</text>
+    </svg>
+  );
+}

--- a/ui/src/data/slashCommands.js
+++ b/ui/src/data/slashCommands.js
@@ -1,0 +1,46 @@
+import { stockList } from "./mockStockData";
+
+export const SLASH_COMMANDS = [
+  {
+    id: "buffett-opinion",
+    label: "Know Buffett's opinion on a stock",
+    description: "Get Warren Buffett's analysis of any stock",
+    template: "What would Buffett think of ",
+  },
+  {
+    id: "trade-like-buffett",
+    label: "Trade like Buffett",
+    description: "Build a portfolio and analyze it through Buffett's lens",
+  },
+];
+
+const EXTRA_STOCKS = [
+  { symbol: "JNJ", name: "Johnson & Johnson" },
+  { symbol: "JPM", name: "JPMorgan Chase" },
+  { symbol: "MSFT", name: "Microsoft" },
+  { symbol: "NVDA", name: "Nvidia" },
+  { symbol: "WMT", name: "Walmart" },
+  { symbol: "TSLA", name: "Tesla" },
+  { symbol: "AMZN", name: "Amazon" },
+  { symbol: "GOOGL", name: "Alphabet (Google)" },
+  { symbol: "META", name: "Meta Platforms" },
+  { symbol: "V", name: "Visa" },
+  { symbol: "MA", name: "Mastercard" },
+  { symbol: "PG", name: "Procter & Gamble" },
+  { symbol: "DIS", name: "Walt Disney" },
+  { symbol: "NFLX", name: "Netflix" },
+  { symbol: "AMD", name: "AMD" },
+  { symbol: "INTC", name: "Intel" },
+  { symbol: "PEP", name: "PepsiCo" },
+  { symbol: "UNH", name: "UnitedHealth" },
+  { symbol: "HD", name: "Home Depot" },
+  { symbol: "CRM", name: "Salesforce" },
+];
+
+// Deduplicated unified stock list
+const seen = new Set();
+export const STOCK_LIST = [...stockList, ...EXTRA_STOCKS].filter((s) => {
+  if (seen.has(s.symbol)) return false;
+  seen.add(s.symbol);
+  return true;
+});

--- a/ui/src/pages/ChatPage.jsx
+++ b/ui/src/pages/ChatPage.jsx
@@ -8,7 +8,8 @@ import ChatInput from '../components/chat/ChatInput';
 import SampleQuestions from '../components/chat/SampleQuestions';
 import ChatSidebar from '../components/chat/ChatSidebar';
 import { useTheme } from '../context/ThemeContext';
-import { sendMessage } from '../services/api';
+import { sendMessage, fetchBuffettAnalysis } from '../services/api';
+import { scoreHex } from '../utils/buffettScoring';
 
 const CONVERSATIONS_KEY = 'buffett-conversations';
 const ACTIVE_KEY = 'buffett-active-chat';
@@ -108,6 +109,110 @@ export default function ChatPage() {
     }
   }
 
+  async function handleSendPortfolio(holdings) {
+    let currentId = activeId;
+    if (!currentId) {
+      const id = generateId();
+      const newConv = {
+        id,
+        title: 'Portfolio Analysis',
+        messages: [],
+        createdAt: Date.now(),
+      };
+      setConversations((prev) => [newConv, ...prev]);
+      setActiveId(id);
+      currentId = id;
+    }
+
+    const summary = holdings.map((h) => `${h.symbol} ${h.weight}%`).join(', ');
+    const userMsg = { role: 'user', content: `Analyze portfolio: ${summary}` };
+
+    setConversations((prev) =>
+      prev.map((c) => {
+        if (c.id !== currentId) return c;
+        const newMsgs = [...c.messages, userMsg];
+        return { ...c, messages: newMsgs, title: deriveTitle(newMsgs) };
+      }),
+    );
+
+    setLoading(true);
+
+    try {
+      const fetched = await Promise.allSettled(
+        holdings.map(async (h) => {
+          const analysis = await fetchBuffettAnalysis(h.symbol);
+          return { symbol: h.symbol, weight: h.weight, analysis };
+        })
+      );
+
+      const results = fetched.map((r, i) => {
+        if (r.status === 'fulfilled') return r.value;
+        return { symbol: holdings[i].symbol, weight: holdings[i].weight, analysis: null };
+      });
+
+      const validResults = results.filter((r) => r.analysis);
+      const totalWtValid = validResults.reduce((s, r) => s + r.weight, 0) || 1;
+
+      const avgPassRate =
+        validResults.length > 0
+          ? validResults.reduce(
+              (s, r) => s + r.analysis.passCount / (r.analysis.totalCriteria || 1),
+              0
+            ) / validResults.length
+          : 0;
+
+      const weightedPassRate =
+        validResults.length > 0
+          ? validResults.reduce(
+              (s, r) =>
+                s + (r.weight / totalWtValid) * (r.analysis.passCount / (r.analysis.totalCriteria || 1)),
+              0
+            )
+          : 0;
+
+      const avgScore = (avgPassRate * 10).toFixed(1);
+      const weightedScore = (weightedPassRate * 10).toFixed(1);
+      const strongPicks = validResults.filter(
+        (r) => r.analysis.passCount / (r.analysis.totalCriteria || 1) >= 0.7
+      ).length;
+
+      const donutSegments = validResults.map((r) => ({
+        symbol: r.symbol,
+        value: r.weight,
+        color: scoreHex(r.analysis.passCount / (r.analysis.totalCriteria || 1)),
+      }));
+
+      const assistantMsg = {
+        role: 'assistant',
+        content: `Portfolio analysis complete for ${results.length} stocks.`,
+        type: 'portfolio-overview',
+        portfolio_data: { holdings, results, avgScore, weightedScore, strongPicks, donutSegments },
+      };
+
+      setConversations((prev) =>
+        prev.map((c) => {
+          if (c.id !== currentId) return c;
+          const newMsgs = [...c.messages, assistantMsg];
+          return { ...c, messages: newMsgs, title: deriveTitle(newMsgs) };
+        }),
+      );
+    } catch {
+      const errorMsg = {
+        role: 'assistant',
+        content:
+          'Sorry, portfolio analysis failed. Make sure the FastAPI server is running (uvicorn server:app --port 8000).',
+      };
+      setConversations((prev) =>
+        prev.map((c) => {
+          if (c.id !== currentId) return c;
+          return { ...c, messages: [...c.messages, errorMsg] };
+        }),
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
   async function handleSend(question) {
     let currentId = activeId;
     if (!currentId) {
@@ -139,11 +244,24 @@ export default function ChatPage() {
       const currentConv = conversations.find((c) => c.id === currentId);
       const history = (currentConv?.messages || []).map(({ role, content }) => ({ role, content }));
       const result = await sendMessage(question, history);
+
+      // If this is a stock query, also fetch Buffett analysis for the "View Detailed Analysis" link
+      const tickerMatch = question.match(/what would buffett think of\s+([A-Z]{1,5})\s*\??$/i);
+      let buffettAnalysis = null;
+      if (tickerMatch) {
+        try {
+          buffettAnalysis = await fetchBuffettAnalysis(tickerMatch[1].toUpperCase());
+        } catch {
+          // Non-critical — chat still works without it
+        }
+      }
+
       const assistantMsg = {
         role: 'assistant',
         content: result.answer,
         sources: result.sources,
         stock_data: result.stock_data,
+        ...(buffettAnalysis && { buffett_analysis: buffettAnalysis }),
       };
       setConversations((prev) =>
         prev.map((c) => {
@@ -262,7 +380,7 @@ export default function ChatPage() {
               </div>
             </div>
           )}
-          <ChatInput onSend={handleSend} disabled={loading} />
+          <ChatInput onSend={handleSend} onSendPortfolio={handleSendPortfolio} disabled={loading} />
         </div>
       </div>
     </div>

--- a/ui/src/pages/TradingPage.jsx
+++ b/ui/src/pages/TradingPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 import { LineChart, FlaskConical, Sparkles } from "lucide-react";
 import StockSelector from "../components/trading/StockSelector";
 import PriceChart from "../components/trading/PriceChart";
@@ -18,14 +19,28 @@ const tabs = [
 ];
 
 export default function TradingPage() {
-  const [activeTab, setActiveTab] = useState("buffett");
-  const [selectedSymbol, setSelectedSymbol] = useState("AAPL");
+  const [searchParams] = useSearchParams();
+  const [activeTab, setActiveTab] = useState(() => {
+    const tab = searchParams.get("tab");
+    return tabs.some((t) => t.id === tab) ? tab : "buffett";
+  });
+  const [selectedSymbol, setSelectedSymbol] = useState(() => {
+    return searchParams.get("symbol")?.toUpperCase() || "AAPL";
+  });
   const [priceData, setPriceData] = useState([]);
   const [priceLoading, setPriceLoading] = useState(false);
   const [period, setPeriod] = useState("6mo");
   const [fundamentals, setFundamentals] = useState(null);
   const [fundamentalsLoading, setFundamentalsLoading] = useState(false);
   const [backtestPriceData, setBacktestPriceData] = useState(null);
+
+  // Sync state from URL params when they change (e.g., navigating from chat)
+  useEffect(() => {
+    const tab = searchParams.get("tab");
+    const symbol = searchParams.get("symbol");
+    if (tab && tabs.some((t) => t.id === tab)) setActiveTab(tab);
+    if (symbol) setSelectedSymbol(symbol.toUpperCase());
+  }, [searchParams]);
 
   useEffect(() => {
     setPriceLoading(true);
@@ -111,7 +126,20 @@ export default function TradingPage() {
       </div>
 
       {/* Trade like Buffett Tab */}
-      {activeTab === "buffett" && <TradeLikeBuffett />}
+      {activeTab === "buffett" && (
+        <TradeLikeBuffett
+          initialHoldings={(() => {
+            const h = searchParams.get("holdings");
+            if (!h) return null;
+            try {
+              return h.split(",").map((s) => {
+                const [symbol, weight] = s.split(":");
+                return { symbol: symbol.toUpperCase(), weight: parseFloat(weight) };
+              }).filter((x) => x.symbol && !isNaN(x.weight) && x.weight > 0);
+            } catch { return null; }
+          })()}
+        />
+      )}
 
       {/* Stock Trading Tab */}
       {activeTab === "trading" && (

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -1,8 +1,8 @@
-export async function sendMessage(question) {
+export async function sendMessage(question, history = []) {
   const res = await fetch("/api/chat", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ question }),
+    body: JSON.stringify({ question, history }),
   });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();

--- a/ui/src/utils/buffettScoring.js
+++ b/ui/src/utils/buffettScoring.js
@@ -1,0 +1,30 @@
+export const SCORE_HEX = { strong: "#10b981", mixed: "#f59e0b", weak: "#ef4444", none: "#94a3b8" };
+
+export function scoreHex(passRate) {
+  if (passRate >= 0.7) return SCORE_HEX.strong;
+  if (passRate >= 0.4) return SCORE_HEX.mixed;
+  return SCORE_HEX.weak;
+}
+
+export function getScoreStyle(passRate) {
+  if (passRate >= 0.7)
+    return {
+      bg: "bg-emerald-50 dark:bg-emerald-500/10",
+      text: "text-emerald-700 dark:text-emerald-400",
+      badge: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400",
+      label: "Strong",
+    };
+  if (passRate >= 0.4)
+    return {
+      bg: "bg-amber-50 dark:bg-amber-500/10",
+      text: "text-amber-700 dark:text-amber-400",
+      badge: "bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400",
+      label: "Mixed",
+    };
+  return {
+    bg: "bg-red-50 dark:bg-red-500/10",
+    text: "text-red-700 dark:text-red-400",
+    badge: "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400",
+    label: "Weak",
+  };
+}


### PR DESCRIPTION
## Summary

- Add `/` slash command menu to the chat input with two commands: **"Know Buffett's opinion on a stock"** and **"Trade like Buffett"**
- **Buffett Opinion flow**: template pre-fill, stock autocomplete, Buffett analysis fetch, "View Detailed Analysis" deep link to Trading page
- **Portfolio Builder flow**: inline portfolio builder in chat (add stocks + weights), portfolio overview card with donut chart and Buffett scores rendered in conversation
- Deep linking from chat to Trading page with URL params (tab, symbol, holdings) — auto-loads and auto-analyzes on navigation
- Extract shared components (DonutChart, scoring utils) for reuse across chat and trading pages
- Fix `sendMessage` API to pass conversation history to backend

## Test plan

- [ ] Type `/` in chat input — menu appears with 2 options, arrow keys navigate, Enter selects, Escape dismisses
- [ ] Select "Know Buffett's opinion" — template pre-fills, typing shows stock autocomplete, selecting completes the question
- [ ] Submit stock opinion question — response shows stock card + answer + "View Detailed Analysis" button
- [ ] Click "View Detailed Analysis" — navigates to Trading page with correct stock selected
- [ ] Select "Trade like Buffett" — input transforms to portfolio builder with ticker/weight inputs and suggested stock pills
- [ ] Add stocks, click "Analyze Portfolio" — portfolio overview card renders in chat (donut chart, scores)
- [ ] Click "See Detailed Analysis" on portfolio card — navigates to Trade like Buffett tab with holdings pre-loaded and auto-analyzed
- [ ] Normal chat messages still work without slash commands
- [ ] Trade like Buffett page on /trading still works independently